### PR TITLE
Problem: Old FS pathnames should be used to upgrade in-place

### DIFF
--- a/fty-nutconfig
+++ b/fty-nutconfig
@@ -21,7 +21,7 @@
 #  \author  Tomas Halman <TomasHalman@Eaton.com>
 #           Michal Vyskocil <MichalVyskocil@Eaton.com>
 #  \details Helper script for autoconfig agent. It creates new NUT configuration
-#           from files stored in /var/lib/fty/nut/devices.
+#           from files stored in /var/lib/bios/nut/devices.
 
 set -e
 
@@ -36,7 +36,9 @@ die() {
 }
 
 TMPDIR=${TMPDIR:-/tmp}
-BIOSCONFDIR=/var/lib/fty/nut/devices
+# TODO: Change later to parametrised names and un-legacy bios=>fty
+#BIOSCONFDIR=/var/lib/fty/nut/devices
+BIOSCONFDIR=/var/lib/bios/nut/devices
 NUTCONFIGDIR=/etc/nut
 [ -d "$NUTCONFIGDIR" ] || NUTCONFIGDIR=/etc/ups
 [ -d "$NUTCONFIGDIR" ] || die "NUT configuration directory not found"

--- a/src/alert_actor.cc
+++ b/src/alert_actor.cc
@@ -25,6 +25,15 @@
 #include "alert_device_list.h"
 #include "logger.h"
 
+/* TODO: Change later to parametrised names and un-legacy bios=>fty :
+static const char* PATH = "/var/lib/fty/nut";
+static const char* STATE = "/var/lib/fty/nut/state_file";
+ */
+/* No consumers for PATH at this time:
+static const char* PATH = "/var/lib/bios/nut";
+ */
+static const char* STATE = "/var/lib/bios/nut/state_file";
+
 int
 alert_actor_commands (
     mlm_client_t *client,
@@ -195,9 +204,9 @@ alert_actor (zsock_t *pipe, void *args)
     log_debug ("alert actor started");
 
     nut_t *stateData = nut_new ();
-    int rv = nut_load (stateData, "/var/lib/fty/nut/state_file");
+    int rv = nut_load (stateData, STATE);
     if (rv != 0) {
-        log_warning ("Could not load state file '%s'.", "/var/lib/fty/nut/state_file");
+        log_warning ("Could not load state file '%s'.", STATE);
     }
     devices.updateDeviceList (stateData);
     while (!zsys_interrupted) {

--- a/src/fty-nut.conf.in
+++ b/src/fty-nut.conf.in
@@ -1,4 +1,8 @@
 # create runtime directories for fty-nut
-d /var/lib/fty/nut 0755 bios root
-d /var/lib/fty/nut/devices 0755 bios bios-infra
-x /var/lib/fty/nut/*
+# TODO: Change later to parametrised names and un-legacy bios=>fty :
+#d /var/lib/fty/nut 0755 bios root
+#d /var/lib/fty/nut/devices 0755 bios bios-infra
+#x /var/lib/fty/nut/*
+d /var/lib/bios/nut 0755 bios root
+d /var/lib/bios/nut/devices 0755 bios bios-infra
+x /var/lib/bios/nut/*

--- a/src/fty-nut.service.in
+++ b/src/fty-nut.service.in
@@ -9,11 +9,15 @@ PartOf=bios.target
 Type=simple
 User=bios
 EnvironmentFile=-@prefix@/share/bios/etc/default/bios
+EnvironmentFile=-@prefix@/share/bios/etc/default/bios__agent-nut.service.conf
 EnvironmentFile=-@prefix@/share/bios/etc/default/bios__%n.conf
 EnvironmentFile=-@sysconfdir@/default/bios
+EnvironmentFile=-@sysconfdir@/default/bios__agent-nut.service.conf
 EnvironmentFile=-@sysconfdir@/default/bios__%n.conf
 Environment="prefix=@prefix@"
-ExecStart=@prefix@/bin/fty-nut --mapping-file @datadir@/@PACKAGE@/mapping.conf --state-file '/var/lib/fty/nut/state_file'
+# TODO: Change later to parametrised names and un-legacy bios=>fty (and remove explicit service files above):
+#ExecStart=@prefix@/bin/fty-nut --mapping-file @datadir@/@PACKAGE@/mapping.conf --state-file '/var/lib/fty/nut/state_file'
+ExecStart=@prefix@/bin/fty-nut --mapping-file @datadir@/agent-nut/mapping.conf --state-file '/var/lib/bios/nut/state_file'
 Restart=always
 
 [Install]

--- a/src/fty_nut_configurator_server.cc
+++ b/src/fty_nut_configurator_server.cc
@@ -36,8 +36,13 @@
 
 /* TODO: This state is shared with core::agent-autoconfig due to needed
  * upgradability from Alpha. Should be cleaned up around/after release. */
+/* TODO: Change later to parametrised names and un-legacy bios=>fty :
 static const char* PATH = "/var/lib/fty/agent-autoconfig";
 static const char* STATE = "/var/lib/fty/agent-autoconfig/state";
+ */
+
+static const char* PATH = "/var/lib/bios/agent-autoconfig";
+static const char* STATE = "/var/lib/bios/agent-autoconfig/state";
 
 static int
 load_agent_info(std::string &info)

--- a/src/fty_nut_server.cc
+++ b/src/fty_nut_server.cc
@@ -28,6 +28,15 @@
 
 #include "fty_nut_classes.h"
 
+/* TODO: Change later to parametrised names and un-legacy bios=>fty :
+static const char* PATH = "/var/lib/fty/nut";
+static const char* STATE = "/var/lib/fty/nut/state_file";
+ */
+/* Consumers of these vars are currently commented away below
+static const char* PATH = "/var/lib/bios/nut";
+static const char* STATE = "/var/lib/bios/nut/state_file";
+ */
+
 static void
 s_handle_poll (NUTAgent& nut_agent, nut_t *data)
 {
@@ -135,9 +144,9 @@ fty_nut_server (zsock_t *pipe, void *args)
 
     zsock_signal (pipe, 0);
 /*
-    r = nut_load (data, "/var/lib/fty/nut/state_file");
+    r = nut_load (data, STATE);
     if (r != 0) {
-        log_warning ("Could not load state file '%s'.", "/var/lib/fty/nut/state_file");
+        log_warning ("Could not load state file '%s'.", STATE);
     }
     nut_agent.updateDeviceList (data);
 */

--- a/src/nut_configurator.cc
+++ b/src/nut_configurator.cc
@@ -38,7 +38,11 @@
 
 using namespace shared;
 
+/* TODO: Change later to parametrised names and un-legacy bios=>fty :
 #define NUT_PART_STORE "/var/lib/fty/nut/devices"
+ */
+
+#define NUT_PART_STORE "/var/lib/bios/nut/devices"
 
 static const char * NUTConfigXMLPattern = "[[:blank:]]driver[[:blank:]]+=[[:blank:]]+\"netxml-ups\"";
 /* TODO: This explicitly lists NUT MIB mappings for the static snmp-ups driver,

--- a/src/sensor_actor.cc
+++ b/src/sensor_actor.cc
@@ -24,6 +24,15 @@
 #include "malamute.h"
 #include "logger.h"
 
+/* TODO: Change later to parametrised names and un-legacy bios=>fty :
+static const char* PATH = "/var/lib/fty/nut";
+static const char* STATE = "/var/lib/fty/nut/state_file";
+ */
+/* No consumers for PATH at this time:
+static const char* PATH = "/var/lib/bios/nut";
+ */
+static const char* STATE = "/var/lib/bios/nut/state_file";
+
 // ugly, declared in actor_commands, TODO: move it to some common
 int
 handle_asset_message (mlm_client_t *client, nut_t *data, zmsg_t **message_p);
@@ -52,9 +61,9 @@ sensor_actor (zsock_t *pipe, void *args)
     log_debug ("sa: sensor actor started");
 
     nut_t *stateData = nut_new ();
-    int rv = nut_load (stateData, "/var/lib/fty/nut/state_file");
+    int rv = nut_load (stateData, STATE);
     if (rv != 0) {
-        log_warning ("Could not load state file '%s'.", "/var/lib/fty/nut/state_file");
+        log_warning ("Could not load state file '%s'.", STATE);
     }
     sensors.updateSensorList (stateData);
     int64_t publishtime = zclock_mono();


### PR DESCRIPTION
Solution: Hardcode old names and leave comments to change them back later

Bonus question: SHOULD this be done? Or do we want to change paths? Opinions differ in various components...