### PR TITLE
Problem: fty-nut-configurator did not reconfigure NUT

### DIFF
--- a/src/fty_10_agent-nut.in
+++ b/src/fty_10_agent-nut.in
@@ -13,7 +13,8 @@
 # Shorthands to reference the specific commands or command-line (shell
 # globs generally) which we may be interested in:
 
-Cmnd_Alias FTY_NUTCONFIG   = @prefix@/bin/fty-nut-configurator
+# The helper script to reconfigure and restart NUT services
+Cmnd_Alias FTY_NUTCONFIG   = @prefix@/bin/fty-nutconfig
 
 # Overall, what is currently allowed with different privileges?
 Cmnd_Alias FTY_AGENT_NUT_PROGS	= FTY_NUTCONFIG

--- a/src/nut_configurator.cc
+++ b/src/nut_configurator.cc
@@ -138,15 +138,16 @@ void NUTConfigurator::systemctl( const std::string &operation, const std::string
 }
 
 void NUTConfigurator::updateNUTConfig() {
-    std::vector<std::string> _argv = { "sudo", "fty-nut-configurator" };
+    // Run the helper script
+    std::vector<std::string> _argv = { "sudo", "fty-nutconfig" };
     SubProcess systemd( _argv );
     if( systemd.run() ) {
         int result = systemd.wait();
-        log_info("sudo fty-nut-configurator %i (%s)",
+        log_info("sudo fty-nutconfig %i (%s)",
                  result,
                  (result == 0 ? "ok" : "failed"));
     } else {
-        log_error("can't run sudo fty-nut-configurator command");
+        log_error("can't run sudo fty-nutconfig command");
     }
 }
 


### PR DESCRIPTION
Solution: fix the typo (did not call the helper script name)

*Now* it works as replacement for old agent. Note that installation should also place the sudoers.d config file into the right place for the OS (not fully done by `make install`) -

````
$ sudo cp /usr/share/bios/examples/config/sudoers.d/fty_10_agent-nut /etc/sudoers.d/
````
