### PR TITLE
Apply bios=>fty renaming for paths (wave one)

### DIFF
--- a/fty-dmf
+++ b/fty-dmf
@@ -85,14 +85,14 @@ do_enable () {
             ON DUPLICATE KEY UPDATE value='true';
             "
     done
-    agent-asset-cli republish "${@}"
+    fty-asset-cli republish "${@}"
 }
 
 do_disable () {
     for id in `get_asset_ids "${@}"`; do
         do_mysql "DELETE FROM v_bios_asset_ext_attributes WHERE (keytag = 'upsconf_enable_dmf' AND id_asset_element=$id)"
     done
-    agent-asset-cli republish "${@}"
+    fty-asset-cli republish "${@}"
 }
 
 do_list () {

--- a/fty-nutconfig
+++ b/fty-nutconfig
@@ -21,7 +21,7 @@
 #  \author  Tomas Halman <TomasHalman@Eaton.com>
 #           Michal Vyskocil <MichalVyskocil@Eaton.com>
 #  \details Helper script for autoconfig agent. It creates new NUT configuration
-#           from files stored in /var/lib/bios/nut/devices.
+#           from files stored in /var/lib/fty/nut/devices.
 
 set -e
 
@@ -36,9 +36,7 @@ die() {
 }
 
 TMPDIR=${TMPDIR:-/tmp}
-# TODO: Change later to parametrised names and un-legacy bios=>fty
-#BIOSCONFDIR=/var/lib/fty/nut/devices
-BIOSCONFDIR=/var/lib/bios/nut/devices
+BIOSCONFDIR=/var/lib/fty/nut/devices
 NUTCONFIGDIR=/etc/nut
 [ -d "$NUTCONFIGDIR" ] || NUTCONFIGDIR=/etc/ups
 [ -d "$NUTCONFIGDIR" ] || die "NUT configuration directory not found"

--- a/src/alert_actor.cc
+++ b/src/alert_actor.cc
@@ -25,14 +25,10 @@
 #include "alert_device_list.h"
 #include "logger.h"
 
-/* TODO: Change later to parametrised names and un-legacy bios=>fty :
-static const char* PATH = "/var/lib/fty/nut";
-static const char* STATE = "/var/lib/fty/nut/state_file";
- */
 /* No consumers for PATH at this time:
-static const char* PATH = "/var/lib/bios/nut";
+static const char* PATH = "/var/lib/fty/nut";
  */
-static const char* STATE = "/var/lib/bios/nut/state_file";
+static const char* STATE = "/var/lib/fty/nut/state_file";
 
 int
 alert_actor_commands (

--- a/src/fty-nut.conf
+++ b/src/fty-nut.conf
@@ -1,8 +1,4 @@
 # create runtime directories for fty-nut
-# TODO: Change later to parametrised names and un-legacy bios=>fty :
-#d /var/lib/fty/nut 0755 bios root
-#d /var/lib/fty/nut/devices 0755 bios bios-infra
-#x /var/lib/fty/nut/*
-d /var/lib/bios/nut 0755 bios root
-d /var/lib/bios/nut/devices 0755 bios bios-infra
-x /var/lib/bios/nut/*
+d /var/lib/fty/nut 0755 bios root
+d /var/lib/fty/nut/devices 0755 bios bios-infra
+x /var/lib/fty/nut/*

--- a/src/fty-nut.service.in
+++ b/src/fty-nut.service.in
@@ -18,7 +18,7 @@ EnvironmentFile=-@sysconfdir@/default/bios
 EnvironmentFile=-@sysconfdir@/default/bios__agent-nut.service.conf
 EnvironmentFile=-@sysconfdir@/default/bios__%n.conf
 Environment="prefix=@prefix@"
-ExecStart=@prefix@/bin/fty-nut --mapping-file @datadir@/fty-nut/mapping.conf --state-file '/var/lib/bios/nut/state_file'
+ExecStart=@prefix@/bin/fty-nut --mapping-file @datadir@/fty-nut/mapping.conf --state-file '/var/lib/fty/nut/state_file'
 Restart=always
 
 [Install]

--- a/src/fty_nut.cc
+++ b/src/fty_nut.cc
@@ -144,13 +144,13 @@ int main (int argc, char *argv [])
     // polling interval
     if (!polling) {
         polling = "30";
-        zconfig_t *root = zconfig_load ("/etc/agent-nut/bios-agent-nut.cfg");
+        zconfig_t *root = zconfig_load ("/etc/fty-nut/fty-nut.cfg");
         if (root) {
             polling = zconfig_get (root, "nut/polling_interval", "30");
             zconfig_destroy (&root);
         }
     }
-    
+
     // log_level cascade (priority ascending)
     //  1. default value
     //  2. env. variable

--- a/src/fty_nut_configurator_server.cc
+++ b/src/fty_nut_configurator_server.cc
@@ -34,15 +34,8 @@
 
 #define MLM_ENDPOINT "ipc://@/malamute"
 
-/* TODO: This state is shared with core::agent-autoconfig due to needed
- * upgradability from Alpha. Should be cleaned up around/after release. */
-/* TODO: Change later to parametrised names and un-legacy bios=>fty :
 static const char* PATH = "/var/lib/fty/agent-autoconfig";
 static const char* STATE = "/var/lib/fty/agent-autoconfig/state";
- */
-
-static const char* PATH = "/var/lib/bios/agent-autoconfig";
-static const char* STATE = "/var/lib/bios/agent-autoconfig/state";
 
 static int
 load_agent_info(std::string &info)

--- a/src/fty_nut_server.cc
+++ b/src/fty_nut_server.cc
@@ -28,13 +28,9 @@
 
 #include "fty_nut_classes.h"
 
-/* TODO: Change later to parametrised names and un-legacy bios=>fty :
+/* Consumers of these vars are currently commented away below
 static const char* PATH = "/var/lib/fty/nut";
 static const char* STATE = "/var/lib/fty/nut/state_file";
- */
-/* Consumers of these vars are currently commented away below
-static const char* PATH = "/var/lib/bios/nut";
-static const char* STATE = "/var/lib/bios/nut/state_file";
  */
 
 static void

--- a/src/nut_configurator.cc
+++ b/src/nut_configurator.cc
@@ -38,11 +38,7 @@
 
 using namespace shared;
 
-/* TODO: Change later to parametrised names and un-legacy bios=>fty :
 #define NUT_PART_STORE "/var/lib/fty/nut/devices"
- */
-
-#define NUT_PART_STORE "/var/lib/bios/nut/devices"
 
 static const char * NUTConfigXMLPattern = "[[:blank:]]driver[[:blank:]]+=[[:blank:]]+\"netxml-ups\"";
 /* TODO: This explicitly lists NUT MIB mappings for the static snmp-ups driver,
@@ -227,13 +223,13 @@ bool NUTConfigurator::configure( const std::string &name, const AutoConfiguratio
             // get polling interval first
             std::string polling = "30";
             {
-                zconfig_t *config = zconfig_load ("/etc/agent-nut/bios-agent-nut.cfg");
+                zconfig_t *config = zconfig_load ("/etc/fty-nut/fty-nut.cfg");
                 if (config) {
                     polling = zconfig_get (config, "nut/polling_interval", "30");
                     zconfig_destroy (&config);
                 }
             }
-            
+
             std::vector<std::string> configs;
 
             std::string IP = "127.0.0.1"; // Fake value for local-media devices or dummy-upses, either passed with an upsconf_block

--- a/src/sensor_actor.cc
+++ b/src/sensor_actor.cc
@@ -24,14 +24,10 @@
 #include "malamute.h"
 #include "logger.h"
 
-/* TODO: Change later to parametrised names and un-legacy bios=>fty :
-static const char* PATH = "/var/lib/fty/nut";
-static const char* STATE = "/var/lib/fty/nut/state_file";
- */
 /* No consumers for PATH at this time:
-static const char* PATH = "/var/lib/bios/nut";
+static const char* PATH = "/var/lib/fty/nut";
  */
-static const char* STATE = "/var/lib/bios/nut/state_file";
+static const char* STATE = "/var/lib/fty/nut/state_file";
 
 // ugly, declared in actor_commands, TODO: move it to some common
 int


### PR DESCRIPTION
Note: review desired - I am not yet certain we actually generate these paths in preinstall etc. (and/or that script should be updated to do so).

Also this does not touch messaging strings for agents this one communicates with, so may need PRs similar to those that happen in other repos - to align naming for intertalk.