### PR TITLE
Problem: input has no units

### DIFF
--- a/src/nut_agent.cc
+++ b/src/nut_agent.cc
@@ -40,6 +40,7 @@ const std::map<std::string, std::string> NUTAgent::_units =
     { "frequency",   "Hz"},
     { "power",       "W" },
     { "runtime",     "s" },
+    { "input",       ""  },
 };
 
 bool NUTAgent::loadMapping (const char *path_to_file)


### PR DESCRIPTION
Solution: define them as ""

Signed-off-by: Tomas Halman <TomasHalman@eaton.com>