### PR TITLE
Problem: ATS input frequency & voltage status is not propagated

### DIFF
--- a/src/mapping.conf
+++ b/src/mapping.conf
@@ -63,7 +63,11 @@
 	"input.1.voltage"       :   "voltage.input.1",
 	"input.2.voltage"       :   "voltage.input.2",
 	"input.source"          :   "input.source",
-	"input.source.preferred" :  "input.source.preferred"
+	"input.source.preferred" :  "input.source.preferred",
+	"input.1.voltage.status" :  "status.input.1.voltage",
+	"input.2.voltage.status" :  "status.input.2.voltage",
+	"input.1.frequency.status" : "status.input.1.frequency",
+	"input.2.frequency.status" : "status.input.2.frequency"
     },
     "physicsMapping - comments" : {
         "input.load" : "not found in nut drivers, including input.L?.load ??",


### PR DESCRIPTION
Solution: Add it to maping file

Signed-off-by: Tomas Halman <TomasHalman@eaton.com>