### PR TITLE
Problem: /var/lib/fty/fty-autoconfig directory needed by agent

### DIFF
--- a/src/fty-nut.conf
+++ b/src/fty-nut.conf
@@ -1,5 +1,7 @@
-# create runtime directories for fty-nut
+# create runtime directories for fty-nut and fty-nut-configurator
 d /var/lib/fty/fty-nut 0755 bios root
 d /var/lib/fty/fty-nut/devices 0755 bios bios-infra
 x /var/lib/fty/fty-nut/*
 x /var/lib/fty/fty-nut/devices/*
+d /var/lib/fty/fty-autoconfig 0755 bios root
+x /var/lib/fty/fty-autoconfig/*

--- a/src/sensor_list.cc
+++ b/src/sensor_list.cc
@@ -80,14 +80,14 @@ void Sensors::updateSensorList (nut_t *config)
         const char *connected_to = nut_asset_location (config, name);
         // do we know where is sensor connected?
         if (streq (connected_to, "")) {
-            log_debug ("sa: sensor %s ingnored (no location)", name);
+            log_debug ("sa: sensor %s ignored (no location)", name);
             name = (char *) zlist_next (sensors);
             continue;
         }
 
         // is it connected to UPS/epdu?
         if ( ! zlist_exists (devices, (void *) connected_to)) {
-            log_debug ("sa: sensor %s connected to unknown location '%s'", name, connected_to);
+            log_debug ("sa: sensor %s ignored (connected to unknown location or not a power device '%s')", name, connected_to);
             name = (char *) zlist_next (sensors);
             continue;
         }


### PR DESCRIPTION
Solution: Create it via tmpfiles

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>