### PR TITLE
PROBLEM: field 'port' is missing in message aux

### DIFF
--- a/src/sensor_device.cc
+++ b/src/sensor_device.cc
@@ -65,7 +65,7 @@ void Sensor::publish (mlm_client_t *client, int ttl)
         zhash_autofree (aux);
         zhash_insert (aux, "port", (void*) port().c_str());
         zmsg_t *msg = fty_proto_encode_metric (
-            NULL,
+            aux,
             time (NULL),
             ttl,
             ("temperature." + port ()).c_str (),


### PR DESCRIPTION
Metric message for humidity, published by fty-nut's sensor actor,
does have 'port' corretly set in aux field:
```
    stream=_METRICS_SENSOR
    sender=agent-nut-sensor
    subject=humidity.0@ROZ.UPS33
    D: 17-05-02 11:35:11 FTY_PROTO_METRIC:
    D: 17-05-02 11:35:11     aux=
    D: 17-05-02 11:35:11         port=0
    D: 17-05-02 11:35:11     time=1493724911
    D: 17-05-02 11:35:11     ttl=60
    D: 17-05-02 11:35:11     type='humidity.0'
    D: 17-05-02 11:35:11     name='ROZ.UPS33'
    D: 17-05-02 11:35:11     value='36.5'
    D: 17-05-02 11:35:11     unit='%'
```

however the same message for temperature does not:
```
    stream=_METRICS_SENSOR
    sender=agent-nut-sensor
    subject=temperature.0@ROZ.UPS33
    D: 17-05-02 11:35:11 FTY_PROTO_METRIC:
    D: 17-05-02 11:35:11     aux=
    D: 17-05-02 11:35:11     time=1493724911
    D: 17-05-02 11:35:11     ttl=60
    D: 17-05-02 11:35:11     type='temperature.0'
    D: 17-05-02 11:35:11     name='ROZ.UPS33'
    D: 17-05-02 11:35:11     value='18.5'
    D: 17-05-02 11:35:11     unit='C'
```

SOLUTION: Fix it.

Signed-off-by: Karol Hrdina <KarolHrdina@Eaton.com>