### PR TITLE
nut.cc : printing of off_t as PRIu64 complains in ARM builds

### DIFF
--- a/src/nut.cc
+++ b/src/nut.cc
@@ -550,7 +550,7 @@ nut_load (nut_t *self, const char *fullpath)
         byte *prefix = zframe_data (frame) + offset;
         byte *data = zframe_data (frame) + offset + sizeof (uint64_t);
         offset += (uint64_t) *prefix +  sizeof (uint64_t);
-        log_debug ("prefix == %" PRIu64 "; offset = %" PRIu64 " ", (uint64_t ) *prefix, offset);
+        log_debug ("prefix == %" PRIu64 "; offset = %jd ", (uint64_t ) *prefix, (intmax_t)offset);
 
 /* Note: the CZMQ_VERSION_MAJOR comparison below actually assumes versions
  * we know and care about - v3.0.2 (our legacy default, already obsoleted


### PR DESCRIPTION
Should fix this report in OBS:

````
[ 2397s]   CXX      src/src_libfty_nut_la-nut.lo
[ 2402s] In file included from src/fty_nut_classes.h:104:0,
[ 2402s]                  from src/nut.cc:29:
[ 2402s] src/nut.cc: In function 'int nut_load(nut_t*, const char*)':
[ 2402s] src/logger.h:75:66: error: format '%llu' expects argument of type 'long long unsigned int', but argument 7 has type 'off_t {aka long int}' [-Werror=format=]
[ 2402s]          log_do((level), __FILE__, __LINE__, __func__, __VA_ARGS__); \
[ 2402s]                                                                   ^
[ 2402s] src/logger.h:80:9: note: in expansion of macro 'log_macro'
[ 2402s]          log_macro(LOG_DEBUG, __VA_ARGS__)
[ 2402s]          ^
[ 2402s] src/nut.cc:553:9: note: in expansion of macro 'log_debug'
[ 2402s]          log_debug ("prefix == %" PRIu64 "; offset = %" PRIu64 " ", (uint64_t ) *prefix, offset);
[ 2402s]          ^
[ 2408s] cc1plus: all warnings being treated as errors
[ 2408s] Makefile:1263: recipe for target 'src/src_libfty_nut_la-nut.lo' failed
[ 2408s] make[2]: *** [src/src_libfty_nut_la-nut.lo] Error 1
[ 2408s] make[2]: Leaving directory '/usr/src/packages/BUILD'
[ 2408s] Makefile:1485: recipe for target 'all-recursive' failed
[ 2408s] make[1]: *** [all-recursive] Error 1
[ 2408s] make[1]: Leaving directory '/usr/src/packages/BUILD'
[ 2408s] dh_auto_build: make -j1 returned exit code 2
[ 2408s] debian/rules:52: recipe for target 'build' failed
[ 2408s] make: *** [build] Error 2
[ 2408s] dpkg-buildpackage: error: debian/rules build gave error exit status 2
````

So far it did not report failures in two other components that have this line, so their fixes were proposed in advance:
* https://github.com/42ity/fty-metric-cache/pull/26
* https://github.com/42ity/fty-alert-list/pull/27