### PR TITLE
Problem: Outlet physical is not published

### DIFF
--- a/src/mapping.conf
+++ b/src/mapping.conf
@@ -123,6 +123,7 @@
         "outlet.switchable"     :       "outlet.switchable",
         "outlet.#.id"           :       "outlet.#.id",
         "outlet.#.desc"         :       "outlet.#.label",
+        "outlet.#.type"         :       "outlet.#.type",
         "outlet.#.groupid"      :       "outlet.#.group",
         "outlet.#.switchable"   :       "outlet.#.switchable",
         "outlet.#.delay.shutdown":      "delay.outlet.#.shutdown",


### PR DESCRIPTION
Solution: Add outlet.#.type to the mapping

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>