### PR TITLE
Problem: outlet.group.#.phase mapping is missing

### DIFF
--- a/src/mapping.conf
+++ b/src/mapping.conf
@@ -133,6 +133,7 @@
         "outlet.group.count"    :       "outlet.group.count",
         "outlet.group.#.name"   :       "outlet.group.#.name",
         "outlet.group.#.count"  :       "outlet.group.#.count",
+        "outlet.group.#.phase"  :       "outlet.group.#.phase",
 
         "outlet.#.status"        :      "status.outlet.#",
         "outlet.#.current.status":      "status.outlet.#.current",


### PR DESCRIPTION
Solution: Add it

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>