### PR TITLE
Problem: outlet.#.name mapping is missing

### DIFF
--- a/src/mapping.conf
+++ b/src/mapping.conf
@@ -127,6 +127,7 @@
         "outlet.count"          :       "outlet.count",
         "outlet.switchable"     :       "outlet.switchable",
         "outlet.#.id"           :       "outlet.#.id",
+        "outlet.#.name"         :       "outlet.#.name",
         "outlet.#.desc"         :       "outlet.#.label",
         "outlet.#.type"         :       "outlet.#.type",
         "outlet.#.groupid"      :       "outlet.#.group",


### PR DESCRIPTION
Solution: Add it

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>