### PR TITLE
Problem: outlet.group.#.name is not coherent

### DIFF
--- a/src/mapping.conf
+++ b/src/mapping.conf
@@ -137,7 +137,7 @@
 
 
         "outlet.group.count"    :       "outlet.group.count",
-        "outlet.group.#.name"   :       "outlet.group.#.name",
+        "outlet.group.#.name"   :       "outlet.group.#.label",
         "outlet.group.#.count"  :       "outlet.group.#.count",
         "outlet.group.#.phase"  :       "outlet.group.#.phase",
 


### PR DESCRIPTION
Solution: Use outlet.group.#.label
Outlets use label for the "friendly" name and name for the static (electrical)
name. Modify our mapping to ensure coherence

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>