### PR TITLE
Problem: Outlet group color is missing

### DIFF
--- a/src/mapping.conf
+++ b/src/mapping.conf
@@ -140,6 +140,7 @@
         "outlet.group.#.name"   :       "outlet.group.#.label",
         "outlet.group.#.count"  :       "outlet.group.#.count",
         "outlet.group.#.phase"  :       "outlet.group.#.phase",
+        "outlet.group.#.color"  :       "outlet.group.#.color",
 
         "outlet.#.status"        :      "status.outlet.#",
         "outlet.#.current.status":      "status.outlet.#.current",


### PR DESCRIPTION
Solution: Add it

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>