### PR TITLE
Problem: Some outlet group data are missing

### DIFF
--- a/src/mapping.conf
+++ b/src/mapping.conf
@@ -75,8 +75,12 @@
         "outlet.#.voltage"      :   "voltage.outlet.#",
         "outlet.#.realpower"    :   "realpower.outlet.#",
         "outlet.#.power"        :   "power.outlet.#",
-        "outlet.group.#.load"   :   "load.outlet.group.#",
-        
+        "outlet.group.#.current"   :   "current.outlet.group.#",
+        "outlet.group.#.voltage"   :   "voltage.outlet.group.#",
+        "outlet.group.#.realpower" :   "realpower.outlet.group.#",
+        "outlet.group.#.power"     :   "power.outlet.group.#",
+        "outlet.group.#.load"      :   "load.outlet.group.#",
+
         //FIXME : move nominal value to inventoryMapping section
         "ups.realpower.nominal" :   "realpower.nominal",
 


### PR DESCRIPTION
Solution: Add these
current and active power were missing, along with apparent power and voltage

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>