### PR TITLE
Problem: Outlet group static name is missing

### DIFF
--- a/src/mapping.conf
+++ b/src/mapping.conf
@@ -141,6 +141,7 @@
 
 
         "outlet.group.count"    :       "outlet.group.count",
+        "outlet.group.#.id"     :       "outlet.group.#.name",
         "outlet.group.#.name"   :       "outlet.group.#.label",
         "outlet.group.#.count"  :       "outlet.group.#.count",
         "outlet.group.#.phase"  :       "outlet.group.#.phase",


### PR DESCRIPTION
Solution: Add it

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>