### PR TITLE
Problem: various problem

### DIFF
--- a/src/fty-nut.cfg.in
+++ b/src/fty-nut.cfg.in
@@ -7,3 +7,5 @@ server
     background = 0      #   Run as background process
     workdir = .         #   Working directory for daemon
     verbose = false     #   Do verbose logging of activity?
+nut
+    polling_interval = 30 # NUT upsd polling interval

--- a/src/fty-nut.cfg.in
+++ b/src/fty-nut.cfg.in
@@ -6,4 +6,4 @@ server
     timeout = 10000     #   Client connection timeout, msec
     background = 0      #   Run as background process
     workdir = .         #   Working directory for daemon
-    verbose = 0         #   Do verbose logging of activity?
+    verbose = false     #   Do verbose logging of activity?

--- a/src/fty_nut.cc
+++ b/src/fty_nut.cc
@@ -126,6 +126,7 @@ int main (int argc, char *argv [])
             case 'v':
             {
                 verbose = 1;
+                log_level = LOG_DEBUG;
                 break;
             }
             case 'p':

--- a/src/fty_nut.cc
+++ b/src/fty_nut.cc
@@ -170,6 +170,8 @@ int main (int argc, char *argv [])
     if (streq (zconfig_get (config, "server/verbose", "false"), "true")) {
         verbose = true;
     }
+    // POLLING
+    polling = zconfig_get (config, "nut/polling_interval", "30");
 
     // log_level cascade (priority ascending)
     //  1. default value

--- a/src/fty_nut_configurator_server.cc
+++ b/src/fty_nut_configurator_server.cc
@@ -127,9 +127,9 @@ s_is_ups_epdu_or_sts (fty_proto_t *bmsg)
 static int
 s_powerdevice_subtype_id (const char *subtype)
 {
-    if (streq (subtype, "ups")) return 1;
-    if (streq (subtype, "epdu")) return 3;
-    if (streq (subtype, "sts")) return 7;
+    if (streq (subtype, "ups")) return asset_subtype::UPS;
+    if (streq (subtype, "epdu")) return asset_subtype::EPDU;
+    if (streq (subtype, "sts")) return asset_subtype::STS;
     return -1;
 }
 


### PR DESCRIPTION
Problem: asset subtype integer values are hardcoded
Solution: Use the existing asset_subtype enum

Problem: verbose mode is not verbose enough
Solution: Enable LOG_DEBUG when verbose is set

Problem: Configuration file is not processed
Solution: Handle configuration file

Problem: NUT polling interval is not configurable
Solution: Make it configurable

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>