### PR TITLE
Change the action field of alert messages to zlist

### DIFF
--- a/src/alert_device.cc
+++ b/src/alert_device.cc
@@ -216,7 +216,7 @@ Device::publishAlert (mlm_client_t *client, DeviceAlert& alert, uint64_t ttl)
         state,              // state
         severity,           // severity
         description.c_str (), // description
-        ""                  // action ?email
+        NULL                // action ?email
     );
     std::string topic = rule + "/" + severity + "@" + _assetName;
     if (message) {


### PR DESCRIPTION
Just a trivial adaptation to a fty-proto change.

Signed-off-by: Michal Marek <MichalMarek1@eaton.com>