### PR TITLE
Change the json rule format to allow for future extensions

### DIFF
--- a/src/alert_device.cc
+++ b/src/alert_device.cc
@@ -290,10 +290,10 @@ Device::publishRule (mlm_client_t *client, DeviceAlert& alert)
         "    { \"high_critical\" : \"" + alert.highCritical + "\"}"
         "    ],"
         "  \"results\"       : ["
-        "    { \"low_critical\"  : { \"action\" : [\"EMAIL\", \"SMS\"], \"severity\":\"CRITICAL\", \"description\" : \"" + alert.name + " is critically low\" }},"
-        "    { \"low_warning\"   : { \"action\" : [\"EMAIL\", \"SMS\"], \"severity\":\"WARNING\" , \"description\" : \"" + alert.name + " is low\"}},"
-        "    { \"high_warning\"  : { \"action\" : [\"EMAIL\", \"SMS\"], \"severity\":\"WARNING\" , \"description\" : \"" + alert.name + " is critically high\" }},"
-        "    { \"high_critical\" : { \"action\" : [\"EMAIL\", \"SMS\"], \"severity\":\"CRITICAL\", \"description\" : \"" + alert.name + " is high\" } }"
+        "    { \"low_critical\"  : { \"action\" : [{\"action\": \"EMAIL\"}, {\"action\": \"SMS\"}], \"severity\":\"CRITICAL\", \"description\" : \"" + alert.name + " is critically low\" }},"
+        "    { \"low_warning\"   : { \"action\" : [{\"action\": \"EMAIL\"}, {\"action\": \"SMS\"}], \"severity\":\"WARNING\" , \"description\" : \"" + alert.name + " is low\"}},"
+        "    { \"high_warning\"  : { \"action\" : [{\"action\": \"EMAIL\"}, {\"action\": \"SMS\"}], \"severity\":\"WARNING\" , \"description\" : \"" + alert.name + " is critically high\" }},"
+        "    { \"high_critical\" : { \"action\" : [{\"action\": \"EMAIL\"}, {\"action\": \"SMS\"}], \"severity\":\"CRITICAL\", \"description\" : \"" + alert.name + " is high\" } }"
         "  ] } }";
     log_debug("aa: publishing rule %s", ruleName.c_str ());
     zmsg_addstr (message, "ADD");

--- a/src/nut_configurator.cc
+++ b/src/nut_configurator.cc
@@ -160,7 +160,7 @@ std::string NUTConfigurator::makeRule(std::string const &alert, std::string cons
         "    \"rule_name\"     :   \"" + alert + "-" + device + "\",\n"
         "    \"target\"        :   [\"status.ups@" + device + "\"],\n"
         "    \"element\"       :   \"" + device + "\",\n"
-        "    \"results\"       :   [ {\"high_critical\"  : { \"action\" : [ \"EMAIL\" ], \"description\" : \""+description+"\" }} ],\n"
+        "    \"results\"       :   [ {\"high_critical\"  : { \"action\" : [{\"action\": \"EMAIL\" }], \"description\" : \""+description+"\" }} ],\n"
         "    \"evaluation\"    : \""
         " function has_bit(x,bit)"
         "     local mask = 2 ^ (bit - 1)"


### PR DESCRIPTION
["EMAIL", "SMS"] -> [{"action": "EMAIL"}, {"action": "SMS"}]

in the generated rules.

Signed-off-by: Michal Marek <MichalMarek1@eaton.com>