### PR TITLE
Problem: malamute client is set twice as consumer

### DIFF
--- a/src/fty_nut_server.cc
+++ b/src/fty_nut_server.cc
@@ -99,10 +99,6 @@ fty_nut_server (zsock_t *pipe, void *args)
         log_critical ("mlm_client_new () failed");
         return;
     }
-    int r = mlm_client_set_consumer (client, FTY_PROTO_STREAM_ASSETS, ".*");
-    if (r == -1) {
-        log_error ("client set_consumer failed");
-    }
 
     // inventory client
     mlm_client_t *iclient = mlm_client_new ();
@@ -110,7 +106,7 @@ fty_nut_server (zsock_t *pipe, void *args)
         log_critical ("mlm_client_new () failed");
         return;
     }
-    r = mlm_client_connect (iclient, "ipc://@/malamute", 5000, "bios-agent-nut-inventory");
+    int r = mlm_client_connect (iclient, "ipc://@/malamute", 5000, "bios-agent-nut-inventory");
     if (r == -1) {
         log_error ("connect of iclient failed");
     }


### PR DESCRIPTION
Solution: one 'set' removed

Signed-off-by: Barbora Stepankova <BarboraStepankova@eaton.com>