### PR TITLE
Problem: NUT alerts are sent before fty-alert-engine adds NUT rules.

### DIFF
--- a/src/alert_actor.cc
+++ b/src/alert_actor.cc
@@ -188,6 +188,12 @@ alert_actor (zsock_t *pipe, void *args)
         log_critical ("mlm_client_new () failed");
         return;
     }
+     mlm_client_t *mb_client = mlm_client_new ();
+     if (!mb_client) {
+        log_critical ("mlm_client_new () failed");
+        return;
+     }
+
     Devices devices;
     devices.setPollingMs (polling);
 
@@ -214,7 +220,7 @@ alert_actor (zsock_t *pipe, void *args)
             last = now;
             zsys_debug ("Polling data now");
             devices.updateFromNUT ();
-            devices.publishRules (client);
+            devices.publishRules (mb_client);
             devices.publishAlerts (client);
         }
         if (which == NULL) {
@@ -243,6 +249,7 @@ alert_actor (zsock_t *pipe, void *args)
         }
     }
     zpoller_destroy (&poller);
+    mlm_client_destroy (&mb_client);
     mlm_client_destroy (&client);
 }
 
@@ -299,8 +306,8 @@ alert_actor_test (bool verbose)
         NULL);
     assert (poller);
 
+    mlm_client_sendtox (rfc_evaluator, "agent-nut-alert", "rfc-evaluator-rules", "OK", NULL);
     devs.publishRules (client);
-    devs.publishAlerts (client);
 
     // check rule message
     {
@@ -324,8 +331,10 @@ alert_actor_test (bool verbose)
         zstr_free (&item);
 
         zmsg_destroy (&msg);
+
     }
     // check alert message
+    devs.publishAlerts (client);
     {
         verbose_printf ("    receive alert\n");
         void *which = zpoller_wait (poller, 1000);

--- a/src/alert_actor.cc
+++ b/src/alert_actor.cc
@@ -331,7 +331,6 @@ alert_actor_test (bool verbose)
         zstr_free (&item);
 
         zmsg_destroy (&msg);
-
     }
     // check alert message
     devs.publishAlerts (client);

--- a/src/alert_device.cc
+++ b/src/alert_device.cc
@@ -299,7 +299,14 @@ Device::publishRule (mlm_client_t *client, DeviceAlert& alert)
     zmsg_addstr (message, "ADD");
     zmsg_addstr (message, rule.c_str ());
     if (mlm_client_sendto (client, "fty-alert-engine", "rfc-evaluator-rules", NULL, 1000, &message) == 0) {
-        alert.rulePublished = true;
+        zmsg_t *resp = mlm_client_recv (client);
+        char *result = zmsg_popstr (resp);
+        if (streq (result, "OK"))
+                alert.rulePublished = true;
+        else
+                zsys_error ("Error requesting fty-alert-engine to ADD rule %s", rule.c_str ());
+        zstr_free (&result);
+        zmsg_destroy (&resp);
     };
     zmsg_destroy (&message);
 }


### PR DESCRIPTION
Solution: Wait for confirmation (which has a nice benefit of getting rid of one memleak in Malamute.)

Signed-off-by: Jana Rapava <janarapava@eaton.com>