### PR TITLE
Fix a use-after-free crash in the alert actor

### DIFF
--- a/src/alert_actor.cc
+++ b/src/alert_actor.cc
@@ -186,10 +186,10 @@ alert_actor_test (bool verbose)
     fty_proto_aux_insert(msg, "type", "device");
     fty_proto_aux_insert(msg, "subtype", "ups");
     fty_proto_ext_insert(msg, "ip.1", "192.0.2.1");
-    AssetState::Asset asset(msg);
+    std::shared_ptr<AssetState::Asset> asset(new AssetState::Asset(msg));
     fty_proto_destroy(&msg);
 
-    Device dev(&asset);
+    Device dev(asset);
     std::map<std::string,std::vector<std::string> > alerts = {
         { "ambient.temperature.status", {"critical-high", "", ""} },
         { "ambient.temperature.high.warning", {"80", "", ""} },

--- a/src/alert_device.h
+++ b/src/alert_device.h
@@ -28,23 +28,26 @@
 
 #include <nutclient.h>
 #include <malamute.h>
+#include <memory>
 #include <string>
 #include <map>
 
 class Device {
  public:
     Device () : _asset(nullptr), _scanned(false) { };
-    Device (const AssetState::Asset *asset) :
+    explicit Device (std::shared_ptr<AssetState::Asset> asset) :
         _asset(asset),
         _nutName(asset->name()),
         _scanned(false)
     { };
-    Device (const AssetState::Asset *asset, const std::string& nut) :
+    Device (std::shared_ptr<AssetState::Asset> asset, const std::string& nut) :
         _asset(asset),
         _nutName(nut),
         _scanned(false)
     { };
 
+    void assetPtr (std::shared_ptr<AssetState::Asset> asset) { _asset = asset; }
+    std::shared_ptr<AssetState::Asset> assetPtr () const { return _asset; }
     void nutName (const std::string& aName) { _nutName = aName; };
     std::string nutName () const { return _nutName; }
     std::string assetName () const
@@ -66,7 +69,7 @@ class Device {
     friend void alert_device_test (bool verbose);
     friend void alert_actor_test (bool verbose);
  private:
-    const AssetState::Asset *_asset;
+    std::shared_ptr<AssetState::Asset> _asset;
     std::string _nutName;
     bool _scanned;
 

--- a/src/alert_device_list.cc
+++ b/src/alert_device_list.cc
@@ -67,6 +67,9 @@ void Devices::addIfNotPresent (Device dev) {
         _devices[dev.assetName ()] = dev;
         return;
     }
+    // At a minimum, we need to update the asset pointer so that the old asset
+    // object can be destroyed
+    it->second.assetPtr(dev.assetPtr());
 }
 
 void Devices::updateDeviceList()
@@ -86,14 +89,14 @@ void Devices::updateDeviceList()
         const std::string& name = i.first;
         switch(i.second->daisychain()) {
         case 0:
-            addIfNotPresent(Device(i.second.get()));
+            addIfNotPresent(Device(i.second));
             break;
         default:
             auto master = deviceState.ip2master(ip);
             if (master.empty()) {
                 log_error("Daisychain host for %s not found", name.c_str());
             } else {
-                addIfNotPresent(Device(i.second.get(), master));
+                addIfNotPresent(Device(i.second, master));
             }
             break;
         }


### PR DESCRIPTION
Unlike the sensor actor and the NUTAgent, the alert actor maintains a
persistent view of the devices. To avoid accessing pointers to Asset
objects that have been deleted, use a shared_ptr to refer to the Asset
object.