### PR TITLE
Rework fty-nut-configurator state handling

### DIFF
--- a/include/fty_nut_configurator_server.h
+++ b/include/fty_nut_configurator_server.h
@@ -34,7 +34,6 @@ class Autoconfig {
     ~Autoconfig () { mlm_client_destroy (&_client);}
 
     void onStart( );
-    void onEnd( ) { cleanupState(); saveState(); };
     void onSend( zmsg_t **message );
     void onPoll( );
     bool connect(
@@ -49,8 +48,6 @@ class Autoconfig {
     void addDeviceIfNeeded(const char *name, uint32_t type, uint32_t subtype);
     void requestExtendedAttributes( const char *name );
     void cleanupState();
-    void saveState();
-    void loadState();
     ConfigFactory _configurator;
     std::map<std::string,AutoConfigurationInfo> _configurableDevices;
 

--- a/include/fty_nut_configurator_server.h
+++ b/include/fty_nut_configurator_server.h
@@ -33,7 +33,6 @@ class Autoconfig {
     explicit Autoconfig( const char *agentName ): _agentName (agentName) {  };
     ~Autoconfig () { mlm_client_destroy (&_client);}
 
-    void onStart( );
     void onSend( zmsg_t **message );
     void onPoll( );
     bool connect(
@@ -43,17 +42,14 @@ class Autoconfig {
     mlm_client_t *client () const {return _client;}
     int timeout () const {return _timeout;}
  private:
-    void sendNewRules(std::vector<std::string> const &rules);
     void setPollingInterval();
     void addDeviceIfNeeded(const char *name, uint32_t type, uint32_t subtype);
-    void requestExtendedAttributes( const char *name );
     void cleanupState();
     ConfigFactory _configurator;
     std::map<std::string,AutoConfigurationInfo> _configurableDevices;
 
  protected:
     mlm_client_t *_client = NULL;
-    int _exitStatus = 0;
     int _timeout = 2000;
     std::string _agentName;
 };

--- a/include/fty_nut_configurator_server.h
+++ b/include/fty_nut_configurator_server.h
@@ -22,35 +22,29 @@
 #ifndef FTY_NUT_CONFIGURATOR_SERVER_H_INCLUDED
 #define FTY_NUT_CONFIGURATOR_SERVER_H_INCLUDED
 
-#include <malamute.h>
+#include "nut_configurator.h"
+#include "state_manager.h"
+
 #include <string>
 #include <vector>
 
-#include "nut_configurator.h"
-
 class Autoconfig {
  public:
-    explicit Autoconfig( const char *agentName ): _agentName (agentName) {  };
-    ~Autoconfig () { mlm_client_destroy (&_client);}
+    explicit Autoconfig(StateManager::Reader* reader);
 
-    void onSend( zmsg_t **message );
-    void onPoll( );
-    bool connect(
-        const char * endpoint,
-        const char *stream,
-        const char *pattern);
-    mlm_client_t *client () const {return _client;}
+    void onPoll();
+    void onUpdate();
     int timeout () const {return _timeout;}
  private:
     void setPollingInterval();
-    void addDeviceIfNeeded(const char *name, uint32_t type, uint32_t subtype);
+    void addDeviceIfNeeded(const std::string& name, AssetState::Asset *asset);
     void cleanupState();
-    std::map<std::string,AutoConfigurationInfo> _configurableDevices;
+    int _traversal_color;
+    std::map<std::string,AutoConfigurationInfo> _configDevices;
+    std::unique_ptr<StateManager::Reader> _state_reader;
 
  protected:
-    mlm_client_t *_client = NULL;
     int _timeout = 2000;
-    std::string _agentName;
 };
 
 

--- a/include/fty_nut_configurator_server.h
+++ b/include/fty_nut_configurator_server.h
@@ -45,7 +45,6 @@ class Autoconfig {
     void setPollingInterval();
     void addDeviceIfNeeded(const char *name, uint32_t type, uint32_t subtype);
     void cleanupState();
-    ConfigFactory _configurator;
     std::map<std::string,AutoConfigurationInfo> _configurableDevices;
 
  protected:

--- a/src/asset_state.cc
+++ b/src/asset_state.cc
@@ -38,6 +38,15 @@ AssetState::Asset::Asset(fty_proto_t* message)
     port_ = fty_proto_ext_string(message, "port", "");
     subtype_ = fty_proto_aux_string(message, "subtype", "");
     location_ = fty_proto_aux_string(message, "parent_name.1", "");
+    const char *block = fty_proto_ext_string(message, "upsconf_block", NULL);
+    if (block) {
+        upsconf_block_ = block;
+        have_upsconf_block_ = true;
+    } else {
+        have_upsconf_block_ = false;
+    }
+    const char *dmf = fty_proto_ext_string(message, "upsconf_enable_dmf", "");
+    upsconf_enable_dmf_ = strcmp(dmf, "true") == 0;
     max_current_ = NAN;
     try {
         max_current_ = std::stod(fty_proto_ext_string(message,

--- a/src/asset_state.h
+++ b/src/asset_state.h
@@ -55,6 +55,18 @@ public:
         {
             return location_;
         }
+        const std::string& upsconf_block() const
+        {
+            return upsconf_block_;
+        }
+        const bool have_upsconf_block() const
+        {
+            return have_upsconf_block_;
+        }
+        const bool upsconf_enable_dmf() const
+        {
+            return upsconf_enable_dmf_;
+        }
         double maxCurrent() const
         {
             return max_current_;
@@ -73,8 +85,11 @@ public:
         std::string port_;
         std::string subtype_;
         std::string location_;
+        std::string upsconf_block_;
         double max_current_;
         double max_power_;
+        bool have_upsconf_block_;
+        bool upsconf_enable_dmf_;
         int daisychain_;
     };
     // Update the state from a received fty_proto message. Return true if an

--- a/src/fty_nut_configurator.cc
+++ b/src/fty_nut_configurator.cc
@@ -27,6 +27,7 @@
 */
 
 #include "fty_nut_configurator_server.h"
+#include "nut_mlm.h"
 
 #include <czmq.h>
 
@@ -55,7 +56,7 @@ int main (int argc, char *argv [])
     if (verbose)
         zsys_info ("fty_nut_configurator - ");
 
-    zactor_t *server = zactor_new (fty_nut_configurator_server, NULL);
+    zactor_t *server = zactor_new (fty_nut_configurator_server, MLM_ENDPOINT_VOID);
 
     // code from src/malamute.c, under MPL
     //  Accept and print any message back from server

--- a/src/fty_nut_configurator_server.cc
+++ b/src/fty_nut_configurator_server.cc
@@ -36,144 +36,69 @@
 
 // autoconfig agent public methods
 
-static bool
-s_is_ups_epdu_or_sts (fty_proto_t *bmsg)
+Autoconfig::Autoconfig(StateManager::Reader* reader)
+    : _state_reader(reader)
+    , _traversal_color(0)
 {
-    assert (bmsg);
-
-    if (!streq (fty_proto_aux_string (bmsg, "type", ""), "device"))
-        return false;
-
-    const char *subtype = fty_proto_aux_string (bmsg, "subtype", "");
-    return streq (subtype, "ups") || streq (subtype, "epdu") || streq (subtype, "sts");
 }
 
-static int
-s_powerdevice_subtype_id (const char *subtype)
+void Autoconfig::onUpdate()
 {
-    if (streq (subtype, "ups")) return asset_subtype::UPS;
-    if (streq (subtype, "epdu")) return asset_subtype::EPDU;
-    if (streq (subtype, "sts")) return asset_subtype::STS;
-    return -1;
-}
-
-static std::map<std::string,std::string>
-s_zhash_to_map(zhash_t *hash)
-{
-    std::map<std::string,std::string> map;
-    char *item = (char *)zhash_first(hash);
-    while(item) {
-        const char * key = zhash_cursor(hash);
-        const char * val = (const char *)zhash_lookup(hash,key);
-        if( key && val ) map[key] = val;
-        item = (char *)zhash_next(hash);
-    }
-    return map;
-}
-
-// see core.git/src/shared/asset_types.h
-static int
-s_operation2i (fty_proto_t *msg)
-{
-    if (!msg) return -1;
-    const char *operation = fty_proto_operation (msg);
-    if (!operation) return -1;
-    const char *status = fty_proto_aux_string (msg, "status", "active");
-    if (streq (status, "nonactive")) {
-        // device is nonactive -> handle it as delete
-        return 2;
-    }
-    if (streq (operation, "create"))
-        return 1;
-    else
-    if (streq (operation, "delete"))
-        return 2;
-    else
-    if (streq (operation, "update"))
-        return 3;
-    return -1;
-}
-
-void Autoconfig::onSend( zmsg_t **message )
-{
-
-    if( ! message || ! *message ) return;
-
-    const char *device_name = NULL;
-    uint32_t subtype = 0;
-    uint64_t count_upsconf_block = 0; // 0 or 1 in practice
-
-    fty_proto_t *bmsg = fty_proto_decode (message);
-    if (!bmsg)
-    {
-        log_warning ("got non fty_proto from %s", mlm_client_sender (_client));
+    if (!_state_reader->refresh())
         return;
+    const AssetState& deviceState = _state_reader->getState();
+    auto& devices = deviceState.getPowerDevices();
+    _traversal_color = !_traversal_color;
+    // Add new devices and mark existing ones as visited
+    for (auto i : devices) {
+        const std::string& name = i.first;
+        auto it = _configDevices.find(name);
+        if (it == _configDevices.end()) {
+            AutoConfigurationInfo device;
+            device.state = AutoConfigurationInfo::STATE_NEW;
+            auto res = _configDevices.insert(std::make_pair(name, device));
+            it = res.first;
+        }
+        // Updates to existing assets result in invalidation of the respective
+        // objects in AssetState, so we need to update our pointer each time
+        it->second.asset = i.second.get();
+        it->second.traversal_color = _traversal_color;
     }
-
-    // ignore non ups/epdu devices - or those with non interesting operation
-    if (!s_is_ups_epdu_or_sts (bmsg) || s_operation2i (bmsg) == -1) {
-        fty_proto_destroy (&bmsg);
-        return;
-    }
-
-    // this is a device that we should configure, we need extended attributes (ip.1 particularly)
-    device_name = fty_proto_name (bmsg);
-    // MVY: 6 is device, for subtype see core.git/src/shared/asset_types.h
-    subtype = s_powerdevice_subtype_id (fty_proto_aux_string (bmsg, "subtype", ""));
-
-    // upsconf_block support - devices with an explicit "upsconf_block"
-    // ext-attribute will be always configured ([ab]using nut-scanner logic
-    // in nut_configurator.cc). Those without the block may differ...
-    count_upsconf_block = fty_proto_ext_number (bmsg, "upsconf_block", 0);
-    if (count_upsconf_block == 0) {
-        // daisy_chain pdu support - only devices with daisy_chain == 1 or no such ext attribute will be configured via nut-scanner
-        if (fty_proto_ext_number (bmsg, "daisy_chain", 0) > 1) {
-            fty_proto_destroy (&bmsg);
-            return;
+    // Mark no longer existing devices for deletion
+    for (auto i : _configDevices) {
+        if (i.second.traversal_color != _traversal_color) {
+            i.second.state = AutoConfigurationInfo::STATE_DELETING;
+            // Not needed, but null pointer derefs are easier to chase down
+            // than use after free bugs
+            i.second.asset = nullptr;
         }
     }
-
-    addDeviceIfNeeded( device_name, 6, subtype );
-    _configurableDevices[device_name].configured = false;
-    _configurableDevices[device_name].attributes.clear();
-    _configurableDevices[device_name].operation = s_operation2i (bmsg);
-    _configurableDevices[device_name].attributes = s_zhash_to_map(fty_proto_ext (bmsg));
-    fty_proto_destroy (&bmsg);
-
-    if (count_upsconf_block == 0) {
-        // For devices in non-verbatim mode, schedule discovery to be attempted
-        setPollingInterval();
-    } else {
-        // For devices in verbatim mode, proceed to configuration even faster
-        _timeout = 100;
-    }
+    setPollingInterval();
 }
 
-void Autoconfig::onPoll( )
+void Autoconfig::onPoll()
 {
-    bool save = false;
-
-    for( auto &it : _configurableDevices) {
-        // check not configured devices
-        if( ! it.second.configured ) {
-            // we don't need extended attributes for deleting configuration
-            // but we need them for update/insert
-            if(
-                ! it.second.attributes.empty() ||
-                it.second.operation == asset_operation::DELETE ||
-                it.second.operation == asset_operation::RETIRE
-            )
-            {
-                NUTConfigurator configurator;
-                if( configurator.configure (it.first, it.second)) {
-                    it.second.configured = true;
-                    save = true;
-                }
-                it.second.date = time(NULL);
-            }
+    for(auto it = _configDevices.begin(); it != _configDevices.end(); ) {
+        NUTConfigurator configurator;
+        switch (it->second.state) {
+        case AutoConfigurationInfo::STATE_NEW:
+        case AutoConfigurationInfo::STATE_CONFIGURING:
+            // check not configured devices
+            if (configurator.configure(it->first, it->second))
+                it->second.state = AutoConfigurationInfo::STATE_CONFIGURED;
+            else
+                it->second.state = AutoConfigurationInfo::STATE_CONFIGURING;
+            break;
+        case AutoConfigurationInfo::STATE_CONFIGURED:
+            // Nothing to do
+            break;
+        case AutoConfigurationInfo::STATE_DELETING:
+            configurator.erase(it->first);
+            it = _configDevices.erase(it);
+            continue;
         }
+        ++it;
     }
-    if( save ) { cleanupState(); }
     setPollingInterval();
 }
 
@@ -181,58 +106,44 @@ void Autoconfig::onPoll( )
 
 void Autoconfig::setPollingInterval( )
 {
-    _timeout = -1;
-    for( auto &it : _configurableDevices) {
-        if( ! it.second.configured ) {
-            if( it.second.date == 0 ) {
-                // there is device that we didn't try to configure
-                // let's try to do it soon
-                _timeout = 5000;
-                return;
+    bool have_quick = false, have_discovery = false, have_failed = false;
+
+    for( auto &it : _configDevices) {
+        switch (it.second.state) {
+        case AutoConfigurationInfo::STATE_NEW:
+            if (it.second.asset->have_upsconf_block()) {
+                // For devices in verbatim mode, proceed to configuration even
+                // faster
+                have_quick = true;
             } else {
-                // we failed to configure some device
-                // let's try after one minute again
-                _timeout = 60000;
+                // Schedule autodiscovery after 5 seconds
+                have_discovery = true;
             }
+            break;
+        case AutoConfigurationInfo::STATE_CONFIGURING:
+            // we failed to configure some device let's try after one minute
+            // again
+            have_failed = true;
+            break;
+        case AutoConfigurationInfo::STATE_CONFIGURED:
+            // Nothing to do
+            break;
+        case AutoConfigurationInfo::STATE_DELETING:
+            // Deletion is also quick to deal with
+            have_quick = true;
         }
     }
-}
-
-void Autoconfig::addDeviceIfNeeded(const char *name, uint32_t type, uint32_t subtype) {
-    if( _configurableDevices.find(name) == _configurableDevices.end() ) {
-        AutoConfigurationInfo device;
-        device.type = type;
-        device.subtype = subtype;
-        _configurableDevices[name] = device;
-    }
-}
-
-void Autoconfig::cleanupState()
-{
-    for( auto it = _configurableDevices.cbegin(); it != _configurableDevices.cend() ; ) {
-        if( it->second.configured ) {
-            _configurableDevices.erase(it++);
-        } else {
-            ++it;
-        }
-    }
-}
-
-bool Autoconfig::connect(
-        const char * endpoint,
-        const char *stream = NULL,
-        const char *pattern = NULL)
-{
-    assert (endpoint);
-
-    _client = mlm_client_new ();
-    mlm_client_connect (_client, endpoint, 5000, _agentName.c_str ());
-    if (stream)
-        mlm_client_set_producer (_client, stream);
-    if (pattern)
-        mlm_client_set_consumer (_client, stream, pattern);
-
-    return true;
+    // This is not entirely correct, we should record the timestamp of the
+    // last configuration attempt for each asset and just select the timeout
+    // of the first asset to expire.
+    if (have_quick)
+        _timeout = 100;
+    else if (have_discovery)
+        _timeout = 5000;
+    else if (have_failed)
+        _timeout = 60000;
+    else
+        _timeout = -1;
 }
 
 void
@@ -240,11 +151,23 @@ fty_nut_configurator_server (zsock_t *pipe, void *args)
 {
     StateManager state_manager;
     StateManager::Writer& state_writer = state_manager.getWriter();
-    Autoconfig agent (ACTOR_CONFIGURATOR_NAME);
-
+    Autoconfig agent(state_manager.getReader());
     const char *endpoint = static_cast<const char *>(args);
-    agent.connect (endpoint, "ASSETS", ".*");
 
+    MlmClientGuard client(mlm_client_new());
+    if (!client) {
+        log_error("mlm_client_new() failed");
+        return;
+    }
+    if (mlm_client_connect(client, endpoint, 5000, ACTOR_CONFIGURATOR_NAME) < 0) {
+        log_error("client %s failed to connect", ACTOR_CONFIGURATOR_NAME);
+        return;
+    }
+    if (mlm_client_set_consumer(client, FTY_PROTO_STREAM_ASSETS, ".*") < 0) {
+        log_error("mlm_client_set_consumer (stream = '%s', pattern = '.*') failed",
+                FTY_PROTO_STREAM_ASSETS);
+        return;
+    }
     // Ge the initial list of assets. This has to be done after subscribing
     // ourselves to the ASSETS stream. And we do not the infrastructure to do
     // this during unit testing
@@ -261,7 +184,7 @@ fty_nut_configurator_server (zsock_t *pipe, void *args)
         get_initial_assets(state_writer, mb_client);
     }
 
-    ZpollerGuard poller(zpoller_new(pipe, mlm_client_msgpipe(agent.client()), NULL));
+    ZpollerGuard poller(zpoller_new(pipe, mlm_client_msgpipe(client), NULL));
 
     zsock_signal (pipe, 0);
     uint64_t last = zclock_mono ();
@@ -283,18 +206,15 @@ fty_nut_configurator_server (zsock_t *pipe, void *args)
             continue;
         }
 
-        zmsg_t *msg = mlm_client_recv (agent.client());
+        zmsg_t *msg = mlm_client_recv(client);
         if (is_fty_proto(msg)) {
-            // This is a temporary hack until the agent is fully migrated to
-            // the StateManager
-            zmsg_t *msg2 = zmsg_dup(msg);
-            agent.onSend (&msg2);
             handle_fty_proto(state_writer, msg);
+            agent.onUpdate();
             continue;
         }
         log_error ("Unhandled message (%s/%s)",
-                mlm_client_command(agent.client()),
-                mlm_client_subject(agent.client()));
+                mlm_client_command(client),
+                mlm_client_subject(client));
         zmsg_print (msg);
         zmsg_destroy (&msg);
     }

--- a/src/fty_nut_configurator_server.cc
+++ b/src/fty_nut_configurator_server.cc
@@ -73,6 +73,18 @@ void Autoconfig::onUpdate()
             i.second.asset = nullptr;
         }
     }
+    // Mark stale snippets for deletion (this can happen after startup)
+    std::vector<std::string> snippets;
+    if (NUTConfigurator::known_assets(snippets)) {
+        for (auto i : snippets) {
+            if (_configDevices.count(i))
+                continue;
+            AutoConfigurationInfo device;
+            device.asset = nullptr;
+            device.state = AutoConfigurationInfo::STATE_DELETING;
+            _configDevices.insert(std::make_pair(i, device));
+        }
+    }
     setPollingInterval();
 }
 

--- a/src/fty_nut_configurator_server.cc
+++ b/src/fty_nut_configurator_server.cc
@@ -164,8 +164,8 @@ void Autoconfig::onPoll( )
                 it.second.operation == asset_operation::RETIRE
             )
             {
-                auto factory = ConfigFactory();
-                if( factory.configureAsset (it.first, it.second)) {
+                NUTConfigurator configurator;
+                if( configurator.configure (it.first, it.second)) {
                     it.second.configured = true;
                     save = true;
                 }

--- a/src/fty_nut_configurator_server.cc
+++ b/src/fty_nut_configurator_server.cc
@@ -36,11 +36,6 @@
 
 // autoconfig agent public methods
 
-void Autoconfig::onStart( )
-{
-    setPollingInterval();
-}
-
 static bool
 s_is_ups_epdu_or_sts (fty_proto_t *bmsg)
 {

--- a/src/nut_configurator.cc
+++ b/src/nut_configurator.cc
@@ -159,40 +159,6 @@ void NUTConfigurator::updateNUTConfig() {
     }
 }
 
-std::string NUTConfigurator::makeRule(std::string const &alert, std::string const &bit, std::string const &device, std::string const &description) const {
-    return
-        "{\n"
-        "\"single\" : {\n"
-        "    \"rule_name\"     :   \"" + alert + "-" + device + "\",\n"
-        "    \"target\"        :   [\"status.ups@" + device + "\"],\n"
-        "    \"element\"       :   \"" + device + "\",\n"
-        "    \"results\"       :   [ {\"high_critical\"  : { \"action\" : [{\"action\": \"EMAIL\" }], \"description\" : \""+description+"\" }} ],\n"
-        "    \"evaluation\"    : \""
-        " function has_bit(x,bit)"
-        "     local mask = 2 ^ (bit - 1)"
-        "     x = x % (2*mask)"
-        "     if x >= mask then return true else return false end"
-        " end"
-        " function main(status)"
-        "     if has_bit(status,"+bit+") then return HIGH_CRITICAL end"
-        "     return OK"
-        " end"
-        "\"\n"
-        "  }\n"
-        "}";
-}
-
-std::vector<std::string> NUTConfigurator::createRules(std::string const &name) {
-    std::vector<std::string> result;
-
-    // bits OB - 5 LB - 7 BYPASS - 9
-
-    result.push_back (makeRule ("onbattery","5",name,"UPS is running on battery!"));
-    result.push_back (makeRule ("lowbattery","7",name,"Battery depleted!"));
-    result.push_back (makeRule ("onbypass","9",name,"UPS is running on bypass!"));
-    return result;
-}
-
 // compute hash (sha-1) of a file
 static char*
 s_digest (const char* file)
@@ -388,45 +354,6 @@ bool NUTConfigurator::configure( const std::string &name, const AutoConfiguratio
         return true; // true means do not try again this
     }
 }
-
-bool Configurator::configure(
-    const std::string &name,
-    const AutoConfigurationInfo &info )
-{
-    log_error("don't know how to configure device %s type %" PRIu32 "/%" PRIu32, name.c_str(), info.type, info.subtype );
-    return true;
-}
-
-std::vector<std::string> Configurator::createRules(std::string const &name) {
-    std::vector<std::string> result;
-    return result;
-}
-
-Configurator * ConfigFactory::getConfigurator( uint32_t type, uint32_t subtype ) {
-    if( type == asset_type::DEVICE && ( subtype == asset_subtype::UPS || subtype == asset_subtype::EPDU || subtype == asset_subtype::STS ) ) {
-        return new NUTConfigurator();
-    }
-    // if( type == "server" ) return ServerConfigurator();
-    // if( type == "wheelbarrow" ) retrun WheelBarrowConfigurator();
-    return new Configurator();
-}
-
-bool ConfigFactory::configureAsset( const std::string &name, AutoConfigurationInfo &info) {
-    log_debug("configuration attempt device name %s type %" PRIu32 "/%" PRIu32, name.c_str(), info.type, info.subtype );
-    Configurator *C = getConfigurator( info.type, info.subtype );
-    bool result = C->configure( name, info );
-    delete C;
-    return result;
-}
-
-std::vector<std::string> ConfigFactory::getNewRules( const std::string &name, AutoConfigurationInfo &info) {
-    log_debug("rules attempt device name %s type %" PRIu32 "/%" PRIu32, name.c_str(), info.type, info.subtype );
-    Configurator *C = getConfigurator( info.type, info.subtype );
-    std::vector<std::string> result = C->createRules (name);
-    delete C;
-    return result;
-}
-
 
 void
 nut_configurator_test (bool verbose)

--- a/src/nut_configurator.cc
+++ b/src/nut_configurator.cc
@@ -194,165 +194,149 @@ s_digest (const std::stringstream& s)
 bool NUTConfigurator::configure( const std::string &name, const AutoConfigurationInfo &info ) {
     log_debug("NUT configurator created");
 
-    switch( info.operation ) {
-    case asset_operation::INSERT:
-    case asset_operation::UPDATE:
-        {
-            // get polling interval first
-            std::string polling = "30";
-            {
-                zconfig_t *config = zconfig_load ("/etc/fty-nut/fty-nut.cfg");
-                if (config) {
-                    polling = zconfig_get (config, "nut/polling_interval", "30");
-                    zconfig_destroy (&config);
-                }
-            }
-
-            std::vector<std::string> configs;
-
-            std::string IP = "127.0.0.1"; // Fake value for local-media devices or dummy-upses, either passed with an upsconf_block
-                // TODO: (lib)nutscan supports local media like serial or USB,
-                // as well as other remote protocols like IPMI. Use them later.
-            auto ubit = info.attributes.find("upsconf_block");
-            if( ubit != info.attributes.end() ) {
-                // TODO: Refactor to optimize string manipulations
-                std::string UBA = ubit->second; // UpsconfBlockAsset - as stored in contents of the asset
-                char SEP = UBA.at(0);
-                if ( SEP == '\0' || UBA.at(1) == '\0' ) {
-                    log_info("device %s is configured with an empty explicit upsconf_block from its asset (adding asset name as NUT device-tag with no config)",
-                        name.c_str());
-                    configs = { "[" + name + "]\n\n" };
-                } else {
-                    // First character of the sufficiently long UB string
-                    // defines the user-selected line separator character
-                    std::string UBN = UBA.substr(1); //UpsconfBlockNut - with EOL chars, without leading SEP character
-                    std::replace( UBN.begin(), UBN.end(), SEP, '\n' );
-                    if ( UBN.at(0) == '[' ) {
-                        log_info("device %s is configured with a complete explicit upsconf_block from its asset: \"%s\" including a custom NUT device-tag",
-                            name.c_str(), UBN.c_str());
-                        configs = { UBN + "\n" };
-                    } else {
-                        log_info("device %s is configured with a content-only explicit upsconf_block from its asset: \"%s\" (prepending asset name as NUT device-tag)",
-                            name.c_str(), UBN.c_str());
-                        configs = { "[" + name + "]\n" + UBN + "\n" };
-                    }
-                }
-            } else {
-                auto ipit = info.attributes.find("ip.1");
-                if( ipit == info.attributes.end() ) {
-                    log_error("device %s has no IP address", name.c_str() );
-                    return true;
-                }
-                IP = ipit->second;
-
-                std::vector <std::string> communities;
-                zconfig_t *config = zconfig_load ("/etc/default/fty.cfg");
-                if (config) {
-                    zconfig_t *item = zconfig_locate (config, "snmp/community");
-                    if (item) {
-                        bool is_array = false;
-                        zconfig_t *child = zconfig_child (item);
-                        while (child) {
-                            if (!streq (zconfig_value (child), "")) {
-                                is_array = true;
-                                communities.push_back (zconfig_value (child));
-                            }
-                            child = zconfig_next (child);
-                        }
-                        if (!is_array && !streq (zconfig_value (item), ""))
-                            communities.push_back (zconfig_value (item));
-                    }
-                    zconfig_destroy (&config);
-                }
-                else {
-                    log_warning ("Config file '%s' could not be read.", "/etc/default/fty.cfg");
-                }
-                communities.push_back ("public");
-
-                bool use_dmf = false;
-                auto use_dmfit = info.attributes.find ("upsconf_enable_dmf");
-                if (use_dmfit != info.attributes.end () && use_dmfit->second == "true")
-                    use_dmf = true;
-
-                for (const auto& c : communities) {
-                    log_debug("Trying community == %s", c.c_str());
-                    if (nut_scan_snmp (name, CIDRAddress (IP), c, use_dmf, configs) == 0 && !configs.empty ()) {
-                        break;
-                    }
-                }
-                nut_scan_xml_http (name, CIDRAddress(IP), configs);
-            }
-
-            auto it = selectBest( configs );
-            if( it == configs.end() ) {
-                log_error("nut-scanner failed for device \"%s\" at IP address \"%s\", no suitable configuration found",
-                    name.c_str(), IP.c_str() );
-                return false; // try again later
-            }
-            std::string deviceDir = NUT_PART_STORE;
-            mkdir_if_needed( deviceDir.c_str() );
-            std::stringstream cfg;
-
-            std::string config_name = std::string(NUT_PART_STORE) + path_separator() + name;
-            char* digest_old = s_digest (config_name.c_str ());
-            cfg << *it;
-            {
-                std::string s = *it;
-                // prototypes expects std::vector <std::string> - lets create fake vector
-                // this is not performance critical code anyway
-                std::vector <std::string> foo = {s};
-                if (isEpdu (foo) && canSnmp (foo)) {
-                    log_debug ("add synchronous = yes");
-                    cfg << "\tsynchronous = yes\n";
-                }
-                if (canXml (foo)) {
-                    log_debug ("add timeout for XML driver");
-                    cfg << "\ttimeout = 15\n";
-                }
-                log_debug ("add polling for driver");
-                if (canSnmp (foo)) {
-                    cfg << "\tpollfreq = " << polling << "\n";
-                } else {
-                    cfg << "\tpollinterval = " << polling << "\n";
-                }
-            }
-            char* digest_new = s_digest (cfg);
-
-            log_debug ("%s: digest_old=%s, digest_new=%s", config_name.c_str (), digest_old ? digest_old : "(null)", digest_new);
-            if (!digest_old || !streq (digest_old, digest_new)) {
-                std::ofstream cfgFile;
-                cfgFile.open (config_name);
-                cfgFile << cfg.str ();
-                cfgFile.flush ();
-                cfgFile.close ();
-                log_info("creating new config file %s/%s", NUT_PART_STORE, name.c_str() );
-                updateNUTConfig ();
-                systemctl ("enable",  std::string("nut-driver@") + name);
-                systemctl ("restart", std::string("nut-driver@") + name);
-                systemctl ("reload-or-restart", "nut-server");
-            }
-            zstr_free (&digest_new);
-            zstr_free (&digest_old);
-            return true;
+    // get polling interval first
+    std::string polling = "30";
+    {
+        zconfig_t *config = zconfig_load ("/etc/fty-nut/fty-nut.cfg");
+        if (config) {
+            polling = zconfig_get (config, "nut/polling_interval", "30");
+            zconfig_destroy (&config);
         }
-    case asset_operation::DELETE:
-    case asset_operation::RETIRE:
-        {
-            log_info("removing configuration file %s/%s", NUT_PART_STORE, name.c_str() );
-            std::string fileName = std::string(NUT_PART_STORE)
-                + path_separator()
-                + name;
-            remove( fileName.c_str() );
-            updateNUTConfig();
-            systemctl("stop",    std::string("nut-driver@") + name);
-            systemctl("disable", std::string("nut-driver@") + name);
-            systemctl("reload-or-restart", "nut-server");
-            return true;
-        }
-    default:
-        log_error("invalid configuration operation %" PRIi8, info.operation);
-        return true; // true means do not try again this
     }
+
+    std::vector<std::string> configs;
+
+    std::string IP = "127.0.0.1"; // Fake value for local-media devices or dummy-upses, either passed with an upsconf_block
+        // TODO: (lib)nutscan supports local media like serial or USB,
+        // as well as other remote protocols like IPMI. Use them later.
+    if(info.asset->have_upsconf_block()) {
+        // TODO: Refactor to optimize string manipulations
+        std::string UBA = info.asset->upsconf_block(); // UpsconfBlockAsset - as stored in contents of the asset
+        char SEP = UBA.at(0);
+        if ( SEP == '\0' || UBA.at(1) == '\0' ) {
+            log_info("device %s is configured with an empty explicit upsconf_block from its asset (adding asset name as NUT device-tag with no config)",
+                name.c_str());
+            configs = { "[" + name + "]\n\n" };
+        } else {
+            // First character of the sufficiently long UB string
+            // defines the user-selected line separator character
+            std::string UBN = UBA.substr(1); //UpsconfBlockNut - with EOL chars, without leading SEP character
+            std::replace( UBN.begin(), UBN.end(), SEP, '\n' );
+            if ( UBN.at(0) == '[' ) {
+                log_info("device %s is configured with a complete explicit upsconf_block from its asset: \"%s\" including a custom NUT device-tag",
+                    name.c_str(), UBN.c_str());
+                configs = { UBN + "\n" };
+            } else {
+                log_info("device %s is configured with a content-only explicit upsconf_block from its asset: \"%s\" (prepending asset name as NUT device-tag)",
+                    name.c_str(), UBN.c_str());
+                configs = { "[" + name + "]\n" + UBN + "\n" };
+            }
+        }
+    } else {
+        if (info.asset->IP().empty()) {
+            log_error("device %s has no IP address", name.c_str() );
+            return true;
+        }
+        IP = info.asset->IP();
+
+        std::vector <std::string> communities;
+        zconfig_t *config = zconfig_load ("/etc/default/fty.cfg");
+        if (config) {
+            zconfig_t *item = zconfig_locate (config, "snmp/community");
+            if (item) {
+                bool is_array = false;
+                zconfig_t *child = zconfig_child (item);
+                while (child) {
+                    if (!streq (zconfig_value (child), "")) {
+                        is_array = true;
+                        communities.push_back (zconfig_value (child));
+                    }
+                    child = zconfig_next (child);
+                }
+                if (!is_array && !streq (zconfig_value (item), ""))
+                    communities.push_back (zconfig_value (item));
+            }
+            zconfig_destroy (&config);
+        }
+        else {
+            log_warning ("Config file '%s' could not be read.", "/etc/default/fty.cfg");
+        }
+        communities.push_back ("public");
+
+        bool use_dmf = info.asset->upsconf_enable_dmf();
+        for (const auto& c : communities) {
+            log_debug("Trying community == %s", c.c_str());
+            if (nut_scan_snmp (name, CIDRAddress (IP), c, use_dmf, configs) == 0 && !configs.empty ()) {
+                break;
+            }
+        }
+        nut_scan_xml_http (name, CIDRAddress(IP), configs);
+    }
+
+    auto it = selectBest( configs );
+    if( it == configs.end() ) {
+        log_error("nut-scanner failed for device \"%s\" at IP address \"%s\", no suitable configuration found",
+            name.c_str(), IP.c_str() );
+        return false; // try again later
+    }
+    std::string deviceDir = NUT_PART_STORE;
+    mkdir_if_needed( deviceDir.c_str() );
+    std::stringstream cfg;
+
+    std::string config_name = std::string(NUT_PART_STORE) + path_separator() + name;
+    char* digest_old = s_digest (config_name.c_str ());
+    cfg << *it;
+    {
+        std::string s = *it;
+        // prototypes expects std::vector <std::string> - lets create fake vector
+        // this is not performance critical code anyway
+        std::vector <std::string> foo = {s};
+        if (isEpdu (foo) && canSnmp (foo)) {
+            log_debug ("add synchronous = yes");
+            cfg << "\tsynchronous = yes\n";
+        }
+        if (canXml (foo)) {
+            log_debug ("add timeout for XML driver");
+            cfg << "\ttimeout = 15\n";
+        }
+        log_debug ("add polling for driver");
+        if (canSnmp (foo)) {
+            cfg << "\tpollfreq = " << polling << "\n";
+        } else {
+            cfg << "\tpollinterval = " << polling << "\n";
+        }
+    }
+    char* digest_new = s_digest (cfg);
+
+    log_debug ("%s: digest_old=%s, digest_new=%s", config_name.c_str (), digest_old ? digest_old : "(null)", digest_new);
+    if (!digest_old || !streq (digest_old, digest_new)) {
+        std::ofstream cfgFile;
+        cfgFile.open (config_name);
+        cfgFile << cfg.str ();
+        cfgFile.flush ();
+        cfgFile.close ();
+        log_info("creating new config file %s/%s", NUT_PART_STORE, name.c_str() );
+        updateNUTConfig ();
+        systemctl ("enable",  std::string("nut-driver@") + name);
+        systemctl ("restart", std::string("nut-driver@") + name);
+        systemctl ("reload-or-restart", "nut-server");
+    }
+    zstr_free (&digest_new);
+    zstr_free (&digest_old);
+    return true;
+}
+
+void NUTConfigurator::erase(const std::string &name)
+{
+    log_info("removing configuration file %s/%s", NUT_PART_STORE, name.c_str());
+    std::string fileName = std::string(NUT_PART_STORE)
+        + path_separator()
+        + name;
+    remove( fileName.c_str() );
+    updateNUTConfig();
+    systemctl("stop",    std::string("nut-driver@") + name);
+    systemctl("disable", std::string("nut-driver@") + name);
+    systemctl("reload-or-restart", "nut-server");
 }
 
 void

--- a/src/nut_configurator.cc
+++ b/src/nut_configurator.cc
@@ -339,6 +339,11 @@ void NUTConfigurator::erase(const std::string &name)
     systemctl("reload-or-restart", "nut-server");
 }
 
+bool NUTConfigurator::known_assets(std::vector<std::string>& assets)
+{
+    return files_in_directory(NUT_PART_STORE, assets);
+}
+
 void
 nut_configurator_test (bool verbose)
 {

--- a/src/nut_configurator.h
+++ b/src/nut_configurator.h
@@ -45,6 +45,7 @@ class NUTConfigurator {
  public:
     bool configure( const std::string &name, const AutoConfigurationInfo &info );
     void erase(const std::string &name);
+    static bool known_assets(std::vector<std::string>& assets);
  private:
     static std::vector<std::string>::const_iterator selectBest( const std::vector<std::string> &configs);
     static void updateNUTConfig();

--- a/src/nut_configurator.h
+++ b/src/nut_configurator.h
@@ -72,39 +72,21 @@ struct AutoConfigurationInfo
     std::map<std::string,std::string> attributes;
 };
 
-class Configurator {
+class NUTConfigurator {
  public:
-    virtual ~Configurator() {};
-    virtual bool configure( const std::string &name, const AutoConfigurationInfo &info );
-    virtual std::vector<std::string> createRules(std::string const &name);
-};
-
-class NUTConfigurator : public Configurator {
- public:
-    virtual ~NUTConfigurator() {};
-    std::vector<std::string>::const_iterator selectBest( const std::vector<std::string> &configs);
-    std::vector<std::string> createRules(std::string const &name);
-    void updateNUTConfig();
     bool configure( const std::string &name, const AutoConfigurationInfo &info );
  private:
-    std::vector<std::string>::const_iterator stringMatch( const std::vector<std::string> &texts, const char *pattern);
-    std::string makeRule(const std::string &alert, const std::string &bit, const std::string &device, std::string const &description) const;
-    bool match( const std::vector<std::string> &texts, const char *pattern);
-    bool isEpdu( const std::vector<std::string> &texts);
-    bool isAts( const std::vector<std::string> &texts);
-    bool isUps( const std::vector<std::string> &texts);
-    bool canSnmp( const std::vector<std::string> &texts);
-    bool canXml( const std::vector<std::string> &texts);
-    std::vector<std::string>::const_iterator getBestSnmpMib( const std::vector<std::string> &configs);
-    void systemctl( const std::string &operation, const std::string &service );
-};
-
-class ConfigFactory {
- public:
-    bool configureAsset( const std::string &name, AutoConfigurationInfo &info );
-    std::vector<std::string> getNewRules( const std::string &name, AutoConfigurationInfo &info);
- private:
-    Configurator * getConfigurator( uint32_t type, uint32_t subtype );
+    static std::vector<std::string>::const_iterator selectBest( const std::vector<std::string> &configs);
+    static void updateNUTConfig();
+    static std::vector<std::string>::const_iterator stringMatch( const std::vector<std::string> &texts, const char *pattern);
+    static bool match( const std::vector<std::string> &texts, const char *pattern);
+    static bool isEpdu( const std::vector<std::string> &texts);
+    static bool isAts( const std::vector<std::string> &texts);
+    static bool isUps( const std::vector<std::string> &texts);
+    static bool canSnmp( const std::vector<std::string> &texts);
+    static bool canXml( const std::vector<std::string> &texts);
+    static std::vector<std::string>::const_iterator getBestSnmpMib( const std::vector<std::string> &configs);
+    static void systemctl( const std::string &operation, const std::string &service );
 };
 
 //  Self test of this class

--- a/src/nut_configurator.h
+++ b/src/nut_configurator.h
@@ -22,59 +22,29 @@
 #ifndef NUT_CONFIGURATOR_H_INCLUDED
 #define NUT_CONFIGURATOR_H_INCLUDED
 
+#include "asset_state.h"
+
 #include <map>
 #include <vector>
 #include <string>
 
-// core.git/src/shared/asset_types.h
-enum asset_type {
-    TUNKNOWN     = 0,
-    GROUP       = 1,
-    DATACENTER  = 2,
-    ROOM        = 3,
-    ROW         = 4,
-    RACK        = 5,
-    DEVICE      = 6
-};
-
-enum asset_subtype {
-    SUNKNOWN = 0,
-    UPS = 1,
-    GENSET,
-    EPDU,
-    PDU,
-    SERVER,
-    FEED,
-    STS,
-    SWITCH,
-    STORAGE,
-    VIRTUAL,
-    N_A = 11
-    /* ATTENTION: don't change N_A id. It is used as default value in init.sql for types, that don't have N_A */
-};
-
-enum asset_operation {
-    INSERT = 1,
-    DELETE,
-    UPDATE,
-    GET,
-    RETIRE
-};
-
-
 struct AutoConfigurationInfo
 {
-    uint32_t type = 0;
-    uint32_t subtype = 0;
-    int8_t operation = 0;
-    bool configured = false;
-    time_t date = 0;
-    std::map<std::string,std::string> attributes;
+    enum {
+        STATE_NEW,
+        STATE_CONFIGURING,
+        STATE_CONFIGURED,
+        STATE_DELETING
+    } state;
+    // Used to mark visited nodes when refreshing the asset list
+    int traversal_color;
+    const AssetState::Asset *asset;
 };
 
 class NUTConfigurator {
  public:
     bool configure( const std::string &name, const AutoConfigurationInfo &info );
+    void erase(const std::string &name);
  private:
     static std::vector<std::string>::const_iterator selectBest( const std::vector<std::string> &configs);
     static void updateNUTConfig();

--- a/src/nut_mlm.h
+++ b/src/nut_mlm.h
@@ -42,6 +42,9 @@ template<typename T, void (*destructor)(T**)>
 class MlmObjGuard
 {
 public:
+    MlmObjGuard()
+        : ptr_(nullptr)
+    {}
     explicit MlmObjGuard(T* ptr)
         : ptr_(ptr)
     {}
@@ -50,7 +53,17 @@ public:
     {
         destructor(&ptr_);
     }
+    T* operator=(T* ptr)
+    {
+        destructor(&ptr_);
+        ptr_ = ptr;
+        return ptr_;
+    }
     operator T*()
+    {
+        return ptr_;
+    }
+    T* get()
     {
         return ptr_;
     }
@@ -61,5 +74,7 @@ private:
 typedef MlmObjGuard<mlm_client_t, mlm_client_destroy> MlmClientGuard;
 typedef MlmObjGuard<zpoller_t, zpoller_destroy> ZpollerGuard;
 typedef MlmObjGuard<zmsg_t, zmsg_destroy> ZmsgGuard;
+typedef MlmObjGuard<zuuid_t, zuuid_destroy> ZuuidGuard;
+typedef MlmObjGuard<char, zstr_free> ZstrGuard;
 
 #endif

--- a/src/nut_mlm.h
+++ b/src/nut_mlm.h
@@ -33,6 +33,7 @@
 #define ACTOR_ALERT_MB_NAME ACTOR_ALERT_NAME "-mb"
 #define ACTOR_SENSOR_NAME "agent-nut-sensor"
 #define ACTOR_CONFIGURATOR_NAME "nut-configurator"
+#define ACTOR_CONFIGURATOR_MB_NAME ACTOR_CONFIGURATOR_NAME "-mb"
 
 #define CONFIG_POLLING "nut/polling_interval"
 #define ACTION_POLLING "POLLING"

--- a/src/nut_mlm.h
+++ b/src/nut_mlm.h
@@ -32,6 +32,7 @@
 #define ACTOR_ALERT_NAME "bios-nut-alert"
 #define ACTOR_ALERT_MB_NAME ACTOR_ALERT_NAME "-mb"
 #define ACTOR_SENSOR_NAME "agent-nut-sensor"
+#define ACTOR_CONFIGURATOR_NAME "nut-configurator"
 
 #define CONFIG_POLLING "nut/polling_interval"
 #define ACTION_POLLING "POLLING"

--- a/src/state_manager.h
+++ b/src/state_manager.h
@@ -147,6 +147,8 @@ private:
 
 // fty_nut_server.cc
 extern StateManager NutStateManager;
+void get_initial_assets(StateManager::Writer& state_writer, mlm_client_t *client);
+void handle_fty_proto(StateManager::Writer& state_writer, zmsg_t *message);
 
 //  Self test of this class
 void state_manager_test (bool verbose);


### PR DESCRIPTION
This pull request removes the json-formatted state file code that never worked and migrates fty-nut-configurator to the StateManager class. The new code makes sure that /var/lib/fty/fty-nut/devices and in turn /etc/nut/ups.conf is in sync with the StateManager's view of assets, even if the agent is restarted. It should be even possible to merge fty-nut-configurator into fty-nut and use a shared StateManager,  but let's not be that intrusive.