### PR TITLE
subprocess: Do not close the same file descriptor twice

### DIFF
--- a/src/subprocess.h
+++ b/src/subprocess.h
@@ -70,6 +70,9 @@ class SubProcess {
         //! \brief get the pipe ends connected to stdin of started program, or -1 if not started
         int getStdin() const { return _inpair[1]; }
 
+	//! \brief close the stdin pipe end
+	int closeStdin();
+
         //! \brief get the pipe ends connected to stdout of started program, or -1 if not started
         int getStdout() const { return _outpair[0]; }
 


### PR DESCRIPTION
Make sure that whenever we close one of the pipe ends, we set it to
PIPE_DEFAULT to avoid closing it again in the destructor. Otherwise, we
could race with a different thread that calls open() or socket()
in-between and gets assigned the same file descriptor.

Signed-off-by: Michal Marek <MichalMarek1@eaton.com>