### PR TITLE
Implement licensing limitation

### DIFF
--- a/src/asset_state.cc
+++ b/src/asset_state.cc
@@ -27,6 +27,7 @@
 */
 
 #include "asset_state.h"
+#include "nut_mlm.h"
 #include "logger.h"
 
 #include <cmath>
@@ -63,7 +64,7 @@ AssetState::Asset::Asset(fty_proto_t* message)
     } catch (...) { }
 }
 
-bool AssetState::updateFromProto(fty_proto_t* message)
+bool AssetState::handleAssetMessage(fty_proto_t* message)
 {
     std::string type(fty_proto_aux_string (message, "type", ""));
 
@@ -93,15 +94,49 @@ bool AssetState::updateFromProto(fty_proto_t* message)
     return true;
 }
 
+// Destroys passed message
+bool AssetState::handleLicensingMessage(zmsg_t* message)
+{
+    ZmsgGuard msg(message);
+    ZstrGuard value(zmsg_popstr(msg));
+    ZstrGuard item(zmsg_popstr(msg));
+    ZstrGuard category(zmsg_popstr(msg));
+    while (value && item && category) {
+        if (streq(category, "POWER_NODES") && streq(item, "MAX_ACTIVE")) {
+            try {
+                license_limit_ = std::stoi(value.get());
+                return true;
+            } catch (...) { }
+        }
+        value = zmsg_popstr(msg);
+        item = zmsg_popstr(msg);
+        category = zmsg_popstr(msg);
+    }
+    return false;
+}
+
+bool AssetState::updateFromProto(fty_proto_t* message)
+{
+    // proto messages are always assumed to be asset updates
+    return handleAssetMessage(message);
+}
+
 bool AssetState::updateFromProto(zmsg_t* message)
 {
-    fty_proto_t *proto = fty_proto_decode (&message);
-    if (!proto) {
-        zmsg_destroy(&message);
-        return false;
+    bool ret;
+    if (is_fty_proto(message)) {
+        fty_proto_t *proto = fty_proto_decode (&message);
+        if (!proto) {
+            zmsg_destroy(&message);
+            return false;
+        }
+        ret =  handleAssetMessage(proto);
+        fty_proto_destroy(&proto);
+    } else {
+
+        // non-proto messages are assumed to be licensing
+        ret = handleLicensingMessage(message);
     }
-    bool ret =  updateFromProto(proto);
-    fty_proto_destroy(&proto);
     return ret;
 }
 
@@ -119,6 +154,19 @@ void AssetState::recompute()
             ip2master_[ip] = i.first;
         }
     }
+    // If a limit is set, simply copy a prefix of powerdevices_ to
+    // allowed_powerdevices_ If requested, we could come up with some more
+    // fancy sorting...
+    allowed_powerdevices_.clear();
+    AssetMap::const_iterator end;
+    if (license_limit_ < 0 || static_cast<size_t>(license_limit_) >= powerdevices_.size()) {
+        end = powerdevices_.end();
+    } else {
+        end = powerdevices_.begin();
+        for (int i = 0; i < license_limit_; ++i)
+            ++end;
+    }
+    allowed_powerdevices_ = AssetMap(powerdevices_.cbegin(), end);
 }
 
 const std::string& AssetState::ip2master(const std::string& ip) const

--- a/src/asset_state.cc
+++ b/src/asset_state.cc
@@ -93,6 +93,18 @@ bool AssetState::updateFromProto(fty_proto_t* message)
     return true;
 }
 
+bool AssetState::updateFromProto(zmsg_t* message)
+{
+    fty_proto_t *proto = fty_proto_decode (&message);
+    if (!proto) {
+        zmsg_destroy(&message);
+        return false;
+    }
+    bool ret =  updateFromProto(proto);
+    fty_proto_destroy(&proto);
+    return ret;
+}
+
 void AssetState::recompute()
 {
     ip2master_.clear();

--- a/src/asset_state.h
+++ b/src/asset_state.h
@@ -103,11 +103,25 @@ public:
     // Use a std::map to process the assets in a defined order each time
     // Additions and removals do not happen _that_ often to worry about
     typedef std::map<std::string, std::shared_ptr<Asset> > AssetMap;
+    // Return a map of power devices allowed by the current license
     const AssetMap& getPowerDevices() const
     {
         return powerdevices_;
     }
+    // Return a map of all power devices
+    const AssetMap& getAllPowerDevices() const
+    {
+        return powerdevices_;
+    }
+    // Return a map of sensors allowed by the current license. We currently
+    // do not limit sensors in the license, so this is identical to
+    // getAllSensors()
     const AssetMap& getSensors() const
+    {
+        return sensors_;
+    }
+    // Return a map of all sensors
+    const AssetMap& getAllSensors() const
     {
         return sensors_;
     }

--- a/src/asset_state.h
+++ b/src/asset_state.h
@@ -98,7 +98,7 @@ public:
     // Same for encoded proto messages or licensing messages which are not
     // proto. Note that this overload destroys the passed zmsg
     bool updateFromProto(zmsg_t* message);
-    // Build the ip2master map
+    // Build the ip2master map and the list of allowed devices
     void recompute();
     // Use a std::map to process the assets in a defined order each time
     // Additions and removals do not happen _that_ often to worry about
@@ -106,7 +106,7 @@ public:
     // Return a map of power devices allowed by the current license
     const AssetMap& getPowerDevices() const
     {
-        return powerdevices_;
+        return allowed_powerdevices_;
     }
     // Return a map of all power devices
     const AssetMap& getAllPowerDevices() const
@@ -128,9 +128,15 @@ public:
     // Return the name of the asset with given IP address
     const std::string& ip2master(const std::string& ip) const;
 private:
+    bool handleAssetMessage(fty_proto_t* message);
+    bool handleLicensingMessage(zmsg_t* message);
     AssetMap powerdevices_;
+    // subset of powerdevices_ that are allowed by the license
+    AssetMap allowed_powerdevices_;
     AssetMap sensors_;
     std::unordered_map<std::string, std::string> ip2master_;
+    // -1 for no limit, otherwise number of powerdevices to allow
+    int license_limit_ = -1;
 };
 
 #endif

--- a/src/asset_state.h
+++ b/src/asset_state.h
@@ -95,6 +95,9 @@ public:
     // Update the state from a received fty_proto message. Return true if an
     // update has actually been performed, false if the message was skipped
     bool updateFromProto(fty_proto_t* message);
+    // Same for encoded proto messages or licensing messages which are not
+    // proto. Note that this overload destroys the passed zmsg
+    bool updateFromProto(zmsg_t* message);
     // Build the ip2master map
     void recompute();
     // Use a std::map to process the assets in a defined order each time

--- a/src/fty_nut_configurator_server.cc
+++ b/src/fty_nut_configurator_server.cc
@@ -222,7 +222,8 @@ fty_nut_configurator_server (zsock_t *pipe, void *args)
 
         zmsg_t *msg = mlm_client_recv(client);
         if (is_fty_proto(msg)) {
-            handle_fty_proto(state_writer, msg);
+            if (state_writer.getState().updateFromProto(msg))
+                state_writer.commit();
             agent.onUpdate();
             continue;
         }

--- a/src/fty_nut_configurator_server.cc
+++ b/src/fty_nut_configurator_server.cc
@@ -48,7 +48,7 @@ void Autoconfig::onUpdate()
     if (!_state_reader->refresh())
         return;
     const AssetState& deviceState = _state_reader->getState();
-    auto& devices = deviceState.getPowerDevices();
+    auto& devices = deviceState.getAllPowerDevices();
     _traversal_color = !_traversal_color;
     // Add new devices and mark existing ones as visited
     for (auto i : devices) {

--- a/src/fty_nut_server.cc
+++ b/src/fty_nut_server.cc
@@ -35,12 +35,46 @@
 
 StateManager NutStateManager;
 
+static bool
+get_initial_licensing(StateManager::Writer& state_writer, mlm_client_t *client)
+{
+    ZuuidGuard uuid(zuuid_new());
+    int err = mlm_client_sendtox(client, "etn-licensing", "LIMITATIONS",
+                "LIMITATION_QUERY", zuuid_str_canonical(uuid), "*", "*", NULL);
+    if (err < 0) {
+        log_error("Sending LIMITATION_QUERY message to etn-licensing failed");
+        return false;
+    }
+    zmsg_t* reply = mlm_client_recv(client);
+    if (!reply) {
+        zmsg_destroy(&reply);
+        log_error("Getting response to LIMITATION_QUERY failed");
+        return false;
+    }
+    ZstrGuard reply_str(zmsg_popstr(reply));
+    if (!reply_str || strcmp(reply_str, zuuid_str_canonical(uuid)) != 0) {
+        zmsg_destroy(&reply);
+        log_warning("Mismatching response to a LIMITATION_QUERY request");
+        return false;
+    }
+    reply_str = zmsg_popstr(reply);
+    if (!reply_str || strcmp(reply_str, "REPLY") != 0) {
+        zmsg_destroy(&reply);
+        log_error("Got malformed message from etn-licensing");
+        return false;
+    }
+    // The rest is a series of value/item/category triplets that
+    // updateFromProto() can grok
+    return state_writer.getState().updateFromProto(reply);
+}
+
 // Query fty-asset about existing devices. This has to be done after
 // subscribing ourselves to the ASSETS stream, to make sure that we do not
 // miss assets created between the mailbox request and the subscription to
 // the stream.
 void
-get_initial_assets(StateManager::Writer& state_writer, mlm_client_t *client)
+get_initial_assets(StateManager::Writer& state_writer, mlm_client_t *client,
+        bool query_licensing)
 {
     zmsg_t *msg = zmsg_new();
     if (!msg) {
@@ -111,6 +145,10 @@ get_initial_assets(StateManager::Writer& state_writer, mlm_client_t *client)
         if (state_writer.getState().updateFromProto(reply))
             changed = true;
     }
+    if (query_licensing) {
+        if (get_initial_licensing(state_writer, client))
+            changed = true;
+    }
     if (changed)
         state_writer.commit();
     log_info("Initial ASSETS request complete");
@@ -158,6 +196,11 @@ fty_nut_server (zsock_t *pipe, void *args)
                 FTY_PROTO_STREAM_ASSETS);
         return;
     }
+    if (mlm_client_set_consumer(client, "LICENSING-ANNOUNCEMENTS", ".*") < 0) {
+        log_error("mlm_client_set_consumer (stream = '%s', pattern = '.*') failed",
+                "LICENSING-ANNOUNCEMENTS");
+        return;
+    }
 
     // inventory client
     MlmClientGuard iclient(mlm_client_new());
@@ -192,7 +235,7 @@ fty_nut_server (zsock_t *pipe, void *args)
     StateManager::Writer& state_writer = NutStateManager.getWriter();
     // (Ab)use the iclient for the initial assets mailbox request, because it
     // will not receive any interfering stream messages
-    get_initial_assets(state_writer, iclient);
+    get_initial_assets(state_writer, iclient, true);
 
     uint64_t timestamp = static_cast<uint64_t> (zclock_mono ());
     uint64_t timeout = 30000;
@@ -243,7 +286,8 @@ fty_nut_server (zsock_t *pipe, void *args)
             log_error ("Given `which == mlm_client_msgpipe (client)`, function `mlm_client_recv ()` returned NULL");
             continue;
         }
-        if (is_fty_proto(message)) {
+        if (is_fty_proto(message) ||
+                strcmp(mlm_client_subject(client), "LIMITATIONS") == 0) {
             if (state_writer.getState().updateFromProto(message))
                 state_writer.commit();
             continue;

--- a/src/state_manager.cc
+++ b/src/state_manager.cc
@@ -241,8 +241,9 @@ public:
             fty_proto_aux_insert(msg, "type", "device");
             fty_proto_aux_insert(msg, "subtype", "epdu");
             fty_proto_ext_insert(msg, "ip.1", "192.0.2.2");
-            writer.getState().updateFromProto(msg);
-            fty_proto_destroy(&msg);
+            // update via encoded zmsg
+            zmsg_t* zmsg = fty_proto_encode(&msg);
+            writer.getState().updateFromProto(zmsg);
             writer.commit();
             assert(manager.states_.size() == 3);
             assert(reader1->refresh());

--- a/src/state_manager.h
+++ b/src/state_manager.h
@@ -148,7 +148,6 @@ private:
 // fty_nut_server.cc
 extern StateManager NutStateManager;
 void get_initial_assets(StateManager::Writer& state_writer, mlm_client_t *client);
-void handle_fty_proto(StateManager::Writer& state_writer, zmsg_t *message);
 
 //  Self test of this class
 void state_manager_test (bool verbose);

--- a/src/state_manager.h
+++ b/src/state_manager.h
@@ -147,7 +147,7 @@ private:
 
 // fty_nut_server.cc
 extern StateManager NutStateManager;
-void get_initial_assets(StateManager::Writer& state_writer, mlm_client_t *client);
+void get_initial_assets(StateManager::Writer& state_writer, mlm_client_t *client, bool query_licensing = false);
 
 //  Self test of this class
 void state_manager_test (bool verbose);


### PR DESCRIPTION
Get current limitation from etn-licensing and limit the number of power devices for which metrics are published. fty-nut-configurator still works with all devices, so as not to lose configuration when a license expires and before it is renewed.