### PR TITLE
Process asset delete messages even if there is no aux field

### DIFF
--- a/src/state_manager.cc
+++ b/src/state_manager.cc
@@ -282,8 +282,6 @@ public:
             assert(msg);
             fty_proto_set_name(msg, "epdu-2");
             fty_proto_set_operation(msg, FTY_PROTO_ASSET_OP_DELETE);
-            fty_proto_aux_insert(msg, "type", "device");
-            fty_proto_aux_insert(msg, "subtype", "epdu");
             writer.getState().updateFromProto(msg);
             fty_proto_destroy(&msg);
             writer.commit();


### PR DESCRIPTION
The asset names are unique, so if it is a sensor or a power device, we
will find it in one of the maps.