### PR TITLE
fty-nut-configurator: Run systemctl actions in batches

### DIFF
--- a/fty-nutconfig
+++ b/fty-nutconfig
@@ -25,6 +25,7 @@
 #           from files stored in /var/lib/fty/fty-nut/devices.
 
 set -e
+shopt -s nullglob
 
 export PATH=/bin:/usr/bin
 export LC_ALL=C
@@ -57,7 +58,7 @@ EOF
 RES=$?
 
 if [ "$RES" = 0 ]; then
-    cat "${BIOSCONFDIR}"/* 2> /dev/null >> "${TMPFILE}" || RES=$?
+    cat "${BIOSCONFDIR}"/* /dev/null 2> /dev/null >> "${TMPFILE}" || RES=$?
 fi
 
 if [ "$RES" = 0 ] && [ ! -s /etc/systemd/system/nut-driver@.service.d/timeout.conf ] ; then

--- a/src/nut_configurator.h
+++ b/src/nut_configurator.h
@@ -24,7 +24,7 @@
 
 #include "asset_state.h"
 
-#include <map>
+#include <set>
 #include <vector>
 #include <string>
 
@@ -43,8 +43,10 @@ struct AutoConfigurationInfo
 
 class NUTConfigurator {
  public:
+    ~NUTConfigurator() { commit(); }
     bool configure( const std::string &name, const AutoConfigurationInfo &info );
     void erase(const std::string &name);
+    void commit();
     static bool known_assets(std::vector<std::string>& assets);
  private:
     static std::vector<std::string>::const_iterator selectBest( const std::vector<std::string> &configs);
@@ -58,6 +60,10 @@ class NUTConfigurator {
     static bool canXml( const std::vector<std::string> &texts);
     static std::vector<std::string>::const_iterator getBestSnmpMib( const std::vector<std::string> &configs);
     static void systemctl( const std::string &operation, const std::string &service );
+    template<typename It>
+    static void systemctl( const std::string &operation, It first, It last );
+    std::set<std::string> start_drivers_;
+    std::set<std::string> stop_drivers_;
 };
 
 //  Self test of this class


### PR DESCRIPTION
In the main loop, process incoming messages as long as there are any and
call Autoconfig::onPoll() only if there is nothing left in the queue.
In NUTConfigurator::configure() and NUTConfigurator::erase(), only
update the configuration snippets and do the restart the services after
all changes in the current round have been processed. This provides a
considerable speed up when importing large number of devices.
