### PR TITLE
Problem: Mapping for realpower on output is missing

### DIFF
--- a/src/mapping.conf
+++ b/src/mapping.conf
@@ -55,6 +55,7 @@
 
         "output.frequency"      :   "frequency.output",
         "output.powerfactor"    :   "powerfactor.output",
+        "output.realpower"      :   "realpower.default",
         "output.L1.realpower"   :   "realpower.output.L1",
         "output.L2.realpower"   :   "realpower.output.L2",
         "output.L3.realpower"   :   "realpower.output.L3",


### PR DESCRIPTION
Solution: Add it

Signed-off-by: Arnaud Quette <ArnaudQuette@Eaton.com>
(cherry picked from commit 32cc8c53c23426e6cd4bfa22f7914e2ad5085f37)