### PR TITLE
Problem : systemclt sequence is not optinized

### DIFF
--- a/src/nut_configurator.cc
+++ b/src/nut_configurator.cc
@@ -316,9 +316,9 @@ bool NUTConfigurator::configure( const std::string &name, const AutoConfiguratio
         cfgFile.flush ();
         cfgFile.close ();
         log_info("creating new config file %s/%s", NUT_PART_STORE, name.c_str() );
-        updateNUTConfig ();
-        systemctl ("enable",  std::string("nut-driver@") + name);
+        updateNUTConfig();
         systemctl ("restart", std::string("nut-driver@") + name);
+        systemctl ("enable",  std::string("nut-driver@") + name);
         systemctl ("reload-or-restart", "nut-server");
     }
     zstr_free (&digest_new);
@@ -333,9 +333,9 @@ void NUTConfigurator::erase(const std::string &name)
         + path_separator()
         + name;
     remove( fileName.c_str() );
-    updateNUTConfig();
-    systemctl("stop",    std::string("nut-driver@") + name);
     systemctl("disable", std::string("nut-driver@") + name);
+    systemctl("stop",    std::string("nut-driver@") + name);
+    updateNUTConfig();
     systemctl("reload-or-restart", "nut-server");
 }
 


### PR DESCRIPTION
Signed-off-by: Gerald Guillaume <geraldguillaume@eaton.com>

Problem 1 : this bellow sequence may does 1 start, 1 stop, 1 start of the driver which is not optimized.
systemctl ("enable",  std::string("nut-driver@") + name);
systemctl ("restart", std::string("nut-driver@") + name);
systemctl ("reload-or-restart", "nut-server");
It is due to dependency with nut-server.service which wants nut-driver.target.

Solution : adapt the sequence to ensure only one start is done
systemctl ("restart", std::string("nut-driver@") + name);
systemctl ("enable",  std::string("nut-driver@") + name);
systemctl ("reload-or-restart", "nut-server");

-------------------------------------------------------------------------------
Problem 2 : this bellow sequence may hang fty-nut-configurator,
updateNUTConfig();
systemctl("stop",    std::string("nut-driver@") + name);
systemctl("disable", std::string("nut-driver@") + name);
systemctl("reload-or-restart", "nut-server");

Investigation: "systemctl stop" command may hang for ever
ppoll([{fd=3, events=POLLIN}], 1, NULL, NULL, 8) = 1 ([{fd=3, revents=POLLIN}])
recvmsg(3, {msg_name(0)=NULL, msg_iov(1)=[{"l\4\1\1m\0\0\0\227\336\0\0z\0\0\0\1\1o\0\31\0\0\0", 24}], msg_controllen=24, {cmsg_len=24, cmsg_level=SOL_SOCKET, cmsg_type=SCM_CREDENTIALS{pid=1, uid=0, gid=0}}, msg_flags=MSG_CMSG_CLOEXEC}, MSG_DONTWAIT|MSG_NOSIGNAL|MSG_CMSG_CLOEXEC) = 24
recvmsg(3, {msg_name(0)=NULL, msg_iov(1)=[{"/org/freedesktop/systemd1\0\0\0\0\0\0\0"..., 229}], msg_controllen=24, {cmsg_len=24, cmsg_level=SOL_SOCKET, cmsg_type=SCM_CREDENTIALS{pid=1, uid=0, gid=0}}, msg_flags=MSG_CMSG_CLOEXEC}, MSG_DONTWAIT|MSG_NOSIGNAL|MSG_CMSG_CLOEXEC) = 229
recvmsg(3, 0xbe9eb6c0, MSG_DONTWAIT|MSG_NOSIGNAL|MSG_CMSG_CLOEXEC) = -1 EAGAIN (Resource temporarily unavailable)

Solution : Review the sequence to do it in the cleanest way
systemctl("disable", std::string("nut-driver@") + name);
systemctl("stop",    std::string("nut-driver@") + name);
updateNUTConfig();
systemctl("reload-or-restart", "nut-server");


