### PR TITLE
backport : systemclt sequence is not optinized

### DIFF
--- a/src/nut_configurator.cc
+++ b/src/nut_configurator.cc
@@ -350,11 +350,11 @@ void NUTConfigurator::erase(const std::string &name)
 
 void NUTConfigurator::commit()
 {
-    updateNUTConfig();
-    systemctl("stop",    stop_drivers_.begin(),  stop_drivers_.end());
     systemctl("disable", stop_drivers_.begin(),  stop_drivers_.end());
-    systemctl("enable",  start_drivers_.begin(), start_drivers_.end());
+    systemctl("stop",    stop_drivers_.begin(),  stop_drivers_.end());
+    updateNUTConfig();
     systemctl("restart", start_drivers_.begin(), start_drivers_.end());
+    systemctl("enable",  start_drivers_.begin(), start_drivers_.end());
     if (!stop_drivers_.empty() || !start_drivers_.empty())
         systemctl("reload-or-restart", "nut-server");
     stop_drivers_.clear();


### PR DESCRIPTION
Signed-off-by: Gerald Guillaume <geraldguillaume@eaton.com>
see https://github.com/42ity/fty-nut/pull/139

