### PR TITLE
Update nut_configurator.cc

### DIFF
--- a/src/nut_configurator.cc
+++ b/src/nut_configurator.cc
@@ -179,7 +179,6 @@ static char*
 s_digest (const char* file)
 {
     assert (file);
-    zdigest_t *digest = zdigest_new ();
 
     int fd = open (file, O_NOFOLLOW | O_RDONLY);
     if (fd == -1) {
@@ -189,6 +188,7 @@ s_digest (const char* file)
     std::string buffer = MlmSubprocess::read_all (fd);
     close (fd);
 
+    zdigest_t *digest = zdigest_new ();
     zdigest_update (digest, (byte*) buffer.c_str (), buffer.size ());
     char *ret = strdup (zdigest_string (digest));
     zdigest_destroy (&digest);


### PR DESCRIPTION
Avoid memory leak and improve performance when there is no input file to make a digest of.