### PR TITLE
 nut_configurator : disable direct management of systemd services 

### DIFF
--- a/fty-nutconfig
+++ b/fty-nutconfig
@@ -1,6 +1,6 @@
 #!/bin/bash
 #
-# Copyright (C) 2014-2017 Eaton
+# Copyright (C) 2014 - 2018 Eaton
 #
 # This program is free software; you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/src/nut_configurator.cc
+++ b/src/nut_configurator.cc
@@ -353,6 +353,8 @@ void NUTConfigurator::commit()
     if (manage_systemctl) {
         systemctl("disable", stop_drivers_.begin(),  stop_drivers_.end());
         systemctl("stop",    stop_drivers_.begin(),  stop_drivers_.end());
+    } else {
+        log_info("Updating NUT configs, expecting it to manage the service units as needed");
     }
     updateNUTConfig();
     if (manage_systemctl) {

--- a/src/nut_configurator.cc
+++ b/src/nut_configurator.cc
@@ -350,13 +350,17 @@ void NUTConfigurator::erase(const std::string &name)
 
 void NUTConfigurator::commit()
 {
-    systemctl("disable", stop_drivers_.begin(),  stop_drivers_.end());
-    systemctl("stop",    stop_drivers_.begin(),  stop_drivers_.end());
+    if (manage_systemctl) {
+        systemctl("disable", stop_drivers_.begin(),  stop_drivers_.end());
+        systemctl("stop",    stop_drivers_.begin(),  stop_drivers_.end());
+    }
     updateNUTConfig();
-    systemctl("restart", start_drivers_.begin(), start_drivers_.end());
-    systemctl("enable",  start_drivers_.begin(), start_drivers_.end());
-    if (!stop_drivers_.empty() || !start_drivers_.empty())
-        systemctl("reload-or-restart", "nut-server");
+    if (manage_systemctl) {
+        systemctl("restart", start_drivers_.begin(), start_drivers_.end());
+        systemctl("enable",  start_drivers_.begin(), start_drivers_.end());
+        if (!stop_drivers_.empty() || !start_drivers_.empty())
+            systemctl("reload-or-restart", "nut-server");
+    }
     stop_drivers_.clear();
     start_drivers_.clear();
 }

--- a/src/nut_configurator.h
+++ b/src/nut_configurator.h
@@ -48,6 +48,11 @@ class NUTConfigurator {
     void erase(const std::string &name);
     void commit();
     static bool known_assets(std::vector<std::string>& assets);
+    // Currently NUT manages services based on config file changes
+    // so nut_configurator should not, and this flag defaults to false.
+    // This may be ripped out completely after testing, so no fuss about
+    // accessor methods to manage this setting.
+    bool manage_systemctl {false};
  private:
     static std::vector<std::string>::const_iterator selectBest( const std::vector<std::string> &configs);
     static void updateNUTConfig();
@@ -64,9 +69,6 @@ class NUTConfigurator {
     static void systemctl( const std::string &operation, It first, It last );
     std::set<std::string> start_drivers_;
     std::set<std::string> stop_drivers_;
-    // Currently NUT manages services based on config file changes
-    // so nut_configurator should not, and this flag defaults to 0.
-    int manage_systemctl {0};
 };
 
 //  Self test of this class

--- a/src/nut_configurator.h
+++ b/src/nut_configurator.h
@@ -64,6 +64,9 @@ class NUTConfigurator {
     static void systemctl( const std::string &operation, It first, It last );
     std::set<std::string> start_drivers_;
     std::set<std::string> stop_drivers_;
+    // Currently NUT manages services based on config file changes
+    // so nut_configurator should not, and this flag defaults to 0.
+    int manage_systemctl {0};
 };
 
 //  Self test of this class


### PR DESCRIPTION
Follow-up for https://github.com/42ity/nut/pull/66

This should avoid potential clash of activities managing system services, and impose a time limit on occasionally freezing `systemctl` operations (which sometimes breaks even without this clash) from NUT side, and remove blockage in fty-nut service (while it waits indefinitely for `systemctl`) so it can just generate the new config and go on processing the messages.

Note: currently this is implemented as a potentially configurable (no methods to do so) run-time flag, rather than ripping the functionality out right away, so we can test how well it behaves.