### PR TITLE
Problem ; fty-nut-configurator has a memory leak

### DIFF
--- a/src/asset_state.cc
+++ b/src/asset_state.cc
@@ -132,7 +132,7 @@ bool AssetState::updateFromProto(fty_proto_t* message)
     return false;
 }
 
-bool AssetState::updateFromProto(zmsg_t* message)
+bool AssetState::updateFromMsg(zmsg_t* message)
 {
     bool ret = false;
     if (is_fty_proto(message)) {

--- a/src/asset_state.h
+++ b/src/asset_state.h
@@ -97,7 +97,7 @@ public:
     bool updateFromProto(fty_proto_t* message);
     // Same for encoded proto messages or licensing messages which are not
     // proto. Note that this overload destroys the passed zmsg
-    bool updateFromProto(zmsg_t* message);
+    bool updateFromMsg(zmsg_t* message);
     // Build the ip2master map and the list of allowed devices
     void recompute();
     // Use a std::map to process the assets in a defined order each time

--- a/src/fty_nut_configurator_server.cc
+++ b/src/fty_nut_configurator_server.cc
@@ -289,6 +289,7 @@ fty_nut_configurator_server (zsock_t *pipe, void *args)
                 if (state_writer.getState().updateFromProto(proto))
                     state_writer.commit();
                 agent.onUpdate();
+                fty_proto_destroy (&proto);
             } else if (fty_proto_id (proto) == FTY_PROTO_METRIC) {
                 // no longer handle licensing limitations as it's been moved to asset state
                 //agent.handleLimitations(&proto);

--- a/src/fty_nut_server.cc
+++ b/src/fty_nut_server.cc
@@ -65,8 +65,8 @@ get_initial_licensing(StateManager::Writer& state_writer, mlm_client_t *client)
         return false;
     }
     // The rest is a series of value/item/category triplets that
-    // updateFromProto() can grok
-    return state_writer.getState().updateFromProto(reply);
+    // updateFromMsg() can grok
+    return state_writer.getState().updateFromMsg(reply);
 }
 
 // Query fty-asset about existing devices. This has to be done after
@@ -143,7 +143,7 @@ get_initial_assets(StateManager::Writer& state_writer, mlm_client_t *client,
             zmsg_destroy(&reply);
             continue;
         }
-        if (state_writer.getState().updateFromProto(reply))
+        if (state_writer.getState().updateFromMsg(reply))
             changed = true;
     }
     if (query_licensing) {
@@ -291,7 +291,7 @@ fty_nut_server (zsock_t *pipe, void *args)
             continue;
         }
         if (is_fty_proto(message)) {
-            if (state_writer.getState().updateFromProto(message))
+            if (state_writer.getState().updateFromMsg(message))
                 state_writer.commit();
             continue;
         }

--- a/src/state_manager.cc
+++ b/src/state_manager.cc
@@ -243,7 +243,7 @@ public:
             fty_proto_ext_insert(msg, "ip.1", "192.0.2.2");
             // update via encoded zmsg
             zmsg_t* zmsg = fty_proto_encode(&msg);
-            writer.getState().updateFromProto(zmsg);
+            writer.getState().updateFromMsg(zmsg);
             writer.commit();
             assert(manager.states_.size() == 3);
             assert(reader1->refresh());


### PR DESCRIPTION
Problem  : fty-nut-configurator calls AssetState::updateFromProto but missed to free the associated proto payload.
Solution : free  the proto payload.

Problem  : There are 2 versions of the function AssetState::updateFromProto, one which free the msg, and the other one which not free it. It's ambigious.   
Solution : use a different naming for different behaviour.
 
Signed-off-by: Gerald Guillaume <geraldguillaume@eaton.com>