### PR TITLE
Problem: nut-driver-enumerator can miss changes of ups.conf happening WHILE it runs

### DIFF
--- a/fty-nutconfig
+++ b/fty-nutconfig
@@ -80,6 +80,12 @@ if [ "$RES" = 0 ] ; then
     if diff -q "${NUTCONFIG}" "${TMPFILE}" ; then
         # Avoid wearing out the flash storage by needless updates
         echo "NUT configuration did not change since last generation" >&2
+
+        # Still work towards regularly reducing the chance that we
+        # could have missed some NUT config changes earlier (posted
+        # while the script was already processing earlier data):
+        /bin/systemctl start --no-block nut-driver-enumerator.service || true
+
         exit 0
     fi
 

--- a/fty-nutconfig
+++ b/fty-nutconfig
@@ -77,6 +77,12 @@ RES=$?
 fi
 
 if [ "$RES" = 0 ] ; then
+    if diff -q "${NUTCONFIG}" "${TMPFILE}" ; then
+        # Avoid wearing out the flash storage by needless updates
+        echo "NUT configuration did not change since last generation" >&2
+        exit 0
+    fi
+
     # This can take a while and needs space; have our moves atomic
     mv -f "${TMPFILE}" "${NUTCONFIG}.tmp" || die "Error moving ups.conf from temporary to final directory"
     mv -f "${NUTCONFIG}.tmp" "${NUTCONFIG}" || die "Error atomically moving ups.conf from temporary to final file"

--- a/fty-nutconfig
+++ b/fty-nutconfig
@@ -77,7 +77,9 @@ RES=$?
 fi
 
 if [ "$RES" = 0 ] ; then
-    mv "${TMPFILE}" "$NUTCONFIG"
+    # This can take a while and needs space; have our moves atomic
+    mv -f "${TMPFILE}" "${NUTCONFIG}.tmp" || die "Error moving ups.conf from temporary to final directory"
+    mv -f "${NUTCONFIG}.tmp" "${NUTCONFIG}" || die "Error atomically moving ups.conf from temporary to final file"
     chmod 0640 "${NUTCONFIG}"
     chown root:nut "${NUTCONFIG}"
     exit 0


### PR DESCRIPTION
Minimize the chance that this happens by making FS operations with `ups.conf` in `fty-nutconfig` atomic (so the file is not processed while half-written); also reduce flash wear by avoiding needless writes (though just in case, do still call nut-driver-enumerator in such case, to cover up whatever we might miss before).

Complements the changes in https://github.com/42ity/nut/pull/69