### PR TITLE
fty-nutconfig : "tickle" the daemonized version of NUT NDE…

### DIFF
--- a/fty-nutconfig
+++ b/fty-nutconfig
@@ -76,16 +76,32 @@ RES=$?
     fi
 fi
 
+tickle_NDE() {
+    # Still work towards regularly reducing the chance that we
+    # could have missed some NUT config changes earlier (posted
+    # while the script was already processing earlier data)...
+    # Note that this somewhat duplicates the activity of a .path
+    # unit, which should also trigger the corresponding activity
+    # when ups.conf is changed, but unlike the path - this code
+    # ensures that the config is re-evaluated after any asset
+    # repubishing and similar events, so would cover up if we
+    # missed something earlier... better late than never...
+
+    echo "FAILSAFE: Tickling NUT nut-driver-enumerator service(s) to regenerate the service units"
+    if /bin/systemctl is-enabled nut-driver-enumerator.service | grep -w enabled ; then
+        /bin/systemctl start --no-block nut-driver-enumerator.service || true
+    fi
+    if /bin/systemctl is-enabled nut-driver-enumerator-daemon.service | grep -w enabled ; then
+        /bin/systemctl reload --no-block nut-driver-enumerator-daemon.service || \
+        /bin/systemctl restart --no-block nut-driver-enumerator-daemon.service || true
+    fi
+}
+
 if [ "$RES" = 0 ] ; then
     if diff -q "${NUTCONFIG}" "${TMPFILE}" ; then
         # Avoid wearing out the flash storage by needless updates
         echo "NUT configuration did not change since last generation" >&2
-
-        # Still work towards regularly reducing the chance that we
-        # could have missed some NUT config changes earlier (posted
-        # while the script was already processing earlier data):
-        /bin/systemctl start --no-block nut-driver-enumerator.service || true
-
+        tickle_NDE
         exit 0
     fi
 
@@ -94,6 +110,7 @@ if [ "$RES" = 0 ] ; then
     mv -f "${NUTCONFIG}.tmp" "${NUTCONFIG}" || die "Error atomically moving ups.conf from temporary to final file"
     chmod 0640 "${NUTCONFIG}"
     chown root:nut "${NUTCONFIG}"
+    tickle_NDE
     exit 0
 else
     rm "${TMPFILE}" >/dev/null 2>&1

--- a/fty-nutconfig
+++ b/fty-nutconfig
@@ -61,6 +61,8 @@ if [ "$RES" = 0 ]; then
     cat "${BIOSCONFDIR}"/* /dev/null 2> /dev/null >> "${TMPFILE}" || RES=$?
 fi
 
+SYSTEMCTL_RELOAD=false
+NDE_RESTART=false
 if [ "$RES" = 0 ] && [ ! -s /etc/systemd/system/nut-driver@.service.d/timeout.conf ] ; then
     # Use drop-in configuration to override settings of a bundled service file
     mkdir -p /etc/systemd/system/nut-driver@.service.d/
@@ -72,8 +74,33 @@ EOF
 RES=$?
     if [ "$RES" = 0 ] ; then
         chown -R root:root /etc/systemd/system/nut-driver@.service.d/
-        /bin/systemctl daemon-reload
+        SYSTEMCTL_RELOAD=true
     fi
+fi
+
+if [ "$RES" = 0 ] \
+&& [ ! -s /etc/systemd/system/nut-driver-enumerator-daemon.service.d/loopfreq.conf ] \
+&& /bin/systemctl is-enabled nut-driver-enumerator-daemon.service | grep -w enabled \
+; then
+    mkdir -p /etc/systemd/system/nut-driver-enumerator-daemon.service.d/
+    cat << EOF > /etc/systemd/system/nut-driver-enumerator-daemon.service.d/loopfreq.conf
+[Service]
+Environment="DAEMON_SLEEP=60"
+EOF
+    RES=$?
+    if [ "$RES" = 0 ] ; then
+        chown -R root:root /etc/systemd/system/nut-driver-enumerator-daemon.service.d/
+        NDE_RESTART=true
+        SYSTEMCTL_RELOAD=true
+    fi
+fi
+
+if $SYSTEMCTL_RELOAD ; then
+    /bin/systemctl daemon-reload
+fi
+
+if $NDE_RESTART ; then
+    /bin/systemctl restart nut-driver-enumerator-daemon.service || true
 fi
 
 tickle_NDE() {


### PR DESCRIPTION
…nut-driver-enumerator service if available

Should play along with 42ity/nut#70 and https://github.com/42ity/fty-core/pull/303