### PR TITLE
Problem : status.ups doesn't include test in progress

### DIFF
--- a/src/mapping.conf
+++ b/src/mapping.conf
@@ -128,6 +128,7 @@
         "ups.serial"            :       "serial_no",
         "battery.date"          :       "battery.date",
         "battery.type"          :       "battery.type",
+        "ups.test.result"       :       "ups.test.result",
 
         "outlet.count"          :       "outlet.count",
         "outlet.switchable"     :       "outlet.switchable",

--- a/src/nut_agent.cc
+++ b/src/nut_agent.cc
@@ -246,11 +246,13 @@ void NUTAgent::advertisePhysics ()
             }
         }
 
-        // BIOS-1185 end
-        // send also status as bitmap
+        // send status and "in progress" test result as a bitmap
         if (device.second.hasProperty ("status.ups")) {
             std::string status_s = device.second.property ("status.ups");
-            uint16_t    status_i = upsstatus_to_int (status_s);
+            std::string test_s = (device.second.hasProperty ("ups.test.result")?
+                device.second.property ("ups.test.result"):
+                "no test initiated");
+            uint16_t    status_i = upsstatus_to_int (status_s, test_s);
             zmsg_t *msg = fty_proto_encode_metric (
                 NULL,
                 time (NULL),
@@ -270,7 +272,8 @@ void NUTAgent::advertisePhysics ()
                 device.second.setChanged ("status.ups", false);
             }
         }
-        //MVY: send also epdu status as bitmap
+        
+        //send epdu outlet status as bitmap
         for (int i = 1; i != 100; i++) {
             std::string property = "status.outlet." + std::to_string (i);
             // assumption, if outlet.10 does not exists, outlet.11 does not as well

--- a/src/ups_status.cc
+++ b/src/ups_status.cc
@@ -27,7 +27,7 @@
 */
 
 #include "ups_status.h"
-
+#include <fty_common_base.h>
 #include <string.h>
 
 // following definition is taken as it is from network ups tool project (dummy-ups.h):
@@ -53,6 +53,7 @@ static status_lkp_t status_info[] = {
     { "DISCHRG", STATUS_DISCHRG },
     { "HB", STATUS_HB },
     { "FSD", STATUS_FSD },
+    { "OT", STATUS_OT },
     { "NULL", 0 },
 };
 
@@ -76,7 +77,7 @@ s_upsstatus_single_status_to_int (const char *status) {
 
 
 uint16_t
-upsstatus_to_int (const char *status)
+upsstatus_to_int (const char *status, const char *test_result)
 {
     uint16_t result = 0;
     char *buff = strdup (status);
@@ -99,13 +100,18 @@ upsstatus_to_int (const char *status)
         free (buff);
         buff = NULL;
     }
+    //detect if a test is in progress 
+    if(streq(test_result,"in progress")){
+        //add "On Test" (OT) flag to ups status
+        result |= s_upsstatus_single_status_to_int ("OT");
+    }
     return result;
 }
 
 uint16_t
-upsstatus_to_int (const std::string& status)
+upsstatus_to_int (const std::string& status, const std::string& test_result)
 {
-    return upsstatus_to_int (status.c_str ());
+    return upsstatus_to_int (status.c_str(), test_result.c_str());
 }
 
 std::string

--- a/src/ups_status.h
+++ b/src/ups_status.h
@@ -44,12 +44,13 @@
 #define STATUS_DISCHRG         (1 << 11)       /* discharging */
 #define STATUS_HB              (1 << 12)       /* High battery */
 #define STATUS_FSD             (1 << 13)       /* Forced Shutdown */
+#define STATUS_OT              (1 << 14)       /* On Test : test in progress */
 
-// converts status from char* format (e.g. "OL CHRG") to bitmap representation
-uint16_t upsstatus_to_int (const char *status);
+// converts status and test result from char* format (e.g. "OL CHRG") to bitmap representation
+uint16_t upsstatus_to_int (const char *status, const char *test_result);
 
 // std::string wrapper for upsstatus_to_int
-uint16_t upsstatus_to_int (const std::string& status);
+uint16_t upsstatus_to_int (const std::string& status,const std::string& test_result );
 
 // converts status from uint16_t bitmap (e.g. STATUS_CHRG|STATUS_OL) to text
 // representation (e.g. "OL CHRG")


### PR DESCRIPTION
Solution : Add "On Test" (OT) to ups.status when ups.test.result=="in progress"
Signed-off-by: Gerald Guillaume <geraldguillaume@eaton.com>