### PR TITLE
Problem: /tmp is full of  tmp nutconfig.xxxxxxx

### DIFF
--- a/fty-nutconfig
+++ b/fty-nutconfig
@@ -49,6 +49,9 @@ chown -R bios:bios-infra "${BIOSCONFDIR}"
 
 TMPFILE=$(mktemp -p "${TMPDIR}" nutconfig.XXXXXXXXXX)
 
+# Handle signals and a graceful shell process exit
+trap "rm -f ${TMPFILE} >/dev/null 2>&1" 0 1 2 3 15
+
 cat << EOF > "${TMPFILE}"
 # Data-walks of networked devices to initialize a NUT driver state
 # can take considerable time; we should allow for that to succeed.


### PR DESCRIPTION
Solution: handle all exits from fty-nutconfig script with a cleanup of the temp file

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>
(cherry picked from commit 5e0a09352dc53220a1612fcf91d035c85a327dd9)