### PR TITLE
Publish alarms as bitfield metric

### DIFF
--- a/src/nut_agent.cc
+++ b/src/nut_agent.cc
@@ -315,7 +315,7 @@ void NUTAgent::advertisePhysics ()
             if (msg) {
                 log_debug ("sending new status for element_src = '%s', value = '%s' (%s)",
                            device.second.assetName().c_str (), std::to_string (status_i).c_str (), status_s.c_str ());
-                subject = "status@" + device.second.assetName ();
+                subject = "status.ups@" + device.second.assetName ();
                 int r = send (subject, &msg);
                 if( r != 0 )
                     log_error("failed to send measurement %s result %i", subject.c_str(), r);

--- a/src/ups_status.cc
+++ b/src/ups_status.cc
@@ -53,6 +53,7 @@ static status_lkp_t status_info[] = {
     { "DISCHRG", STATUS_DISCHRG },
     { "HB", STATUS_HB },
     { "FSD", STATUS_FSD },
+    { "ALARM", STATUS_ALARM },
     { "NULL", 0 },
 };
 

--- a/src/ups_status.h
+++ b/src/ups_status.h
@@ -44,6 +44,7 @@
 #define STATUS_DISCHRG         (1 << 11)       /* discharging */
 #define STATUS_HB              (1 << 12)       /* High battery */
 #define STATUS_FSD             (1 << 13)       /* Forced Shutdown */
+#define STATUS_ALARM           (1 << 14)       /* Device has alarms */
 
 // converts status and test result from char* format (e.g. "OL CHRG") to bitmap representation
 uint16_t upsstatus_to_int (const char *status, const char *test_result);


### PR DESCRIPTION
This is required for fty-alert-engine in order to process UPS alerts.