### PR TITLE
Problem: Same rules can get republished after a scan

### DIFF
--- a/src/alert_device.cc
+++ b/src/alert_device.cc
@@ -1,7 +1,7 @@
 /*  =========================================================================
     alert_device - structure for device producing alerts
 
-    Copyright (C) 2014 - 2016 Eaton
+    Copyright (C) 2014 - 2019 Eaton
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/alert_device_alert.h
+++ b/src/alert_device_alert.h
@@ -32,6 +32,7 @@ struct DeviceAlert {
     std::string status;
     int64_t timestamp = 0;
     bool rulePublished = false;
+    bool ruleRescanned = false;
 };
 
 #endif // __ALERT_DEVICE_ALERT


### PR DESCRIPTION
Solution: Track if an existing DeviceAlert entry was changed during a scan.

Signed-off-by: Jim Klimov <EvgenyKlimov@eaton.com>

See #172 for details. Validate carefully since this potentially changes behavior (should not, looking from outside) :) In particular, changes in accessible device sets or changes of their published capabilities SHOULD cause republish of the new data; rescans of unmodified device sets of unmodified devices SHOULD NOT be republished and later ignored by receiver, wasting time and impacting performance.