### PR TITLE
Backport 1.5.0

### DIFF
--- a/src/alert_device.cc
+++ b/src/alert_device.cc
@@ -1,7 +1,7 @@
 /*  =========================================================================
     alert_device - structure for device producing alerts
 
-    Copyright (C) 2014 - 2016 Eaton
+    Copyright (C) 2014 - 2019 Eaton
 
     This program is free software; you can redistribute it and/or modify
     it under the terms of the GNU General Public License as published by

--- a/src/alert_device_alert.h
+++ b/src/alert_device_alert.h
@@ -32,6 +32,7 @@ struct DeviceAlert {
     std::string status;
     int64_t timestamp = 0;
     bool rulePublished = false;
+    bool ruleRescanned = false;
 };
 
 #endif // __ALERT_DEVICE_ALERT


### PR DESCRIPTION
This should keep fty-alert-engine from processing already exisiting rules and hopefully improve the metrics processing performance.