### PR TITLE
Fixup permission inside fty-nutconfig

### DIFF
--- a/fty-nutconfig
+++ b/fty-nutconfig
@@ -45,7 +45,7 @@ NUTCONFIGDIR=/etc/nut
 NUTCONFIG="$NUTCONFIGDIR/ups.conf"
 
 mkdir -p "${BIOSCONFDIR}"
-chown -R bios:bios-infra "${BIOSCONFDIR}"
+chown -R discovery-monitoring-daemon:bios-infra "${BIOSCONFDIR}"
 
 TMPFILE=$(mktemp -p "${TMPDIR}" nutconfig.XXXXXXXXXX)
 


### PR DESCRIPTION
This script recreates `/var/lib/fty/fty-nut/devices` and sets permissions, without this the system can no longer configure NUT drivers after this is called.

Release branch is not concerned.