### PR TITLE
Add missing zhash_autofree

### DIFF
--- a/src/nut_agent.cc
+++ b/src/nut_agent.cc
@@ -294,6 +294,7 @@ void NUTAgent::advertiseInventory()
     for (auto& device : _deviceList) {
         std::string log;
         zhash_t *inventory = zhash_new ();
+        zhash_autofree(inventory);
         // !advertiseAll = advetise_Not_OnlyChanged
         for (auto& item : device.second.inventory (!advertiseAll) ) {
             if (item.first == "status.ups") {


### PR DESCRIPTION
- using std::string::c_str() caused leak on zhash_insert()

Signed-off-by: Mauro Guerrera <mauroguerrera@eaton.com>