### PR TITLE
[DO NOT MERGE] Endpoint logic for fty-nut-configurator

### DIFF
--- a/src/asset_state.cc
+++ b/src/asset_state.cc
@@ -63,6 +63,13 @@ AssetState::Asset::Asset(fty_proto_t* message)
         daisychain_ = std::stoi(fty_proto_ext_string(message,
                     "daisy_chain", ""));
     } catch (...) { }
+    zhash_t* ext = fty_proto_get_ext(message);
+    for (auto val = reinterpret_cast<char* const>(zhash_first(ext)); val; val = reinterpret_cast<char* const>(zhash_next(ext))) {
+        if (strncmp(zhash_cursor(ext), "endpoint.1.", 11) == 0) {
+            endpoint_.emplace(zhash_cursor(ext)+11, val);
+        }
+    }
+    zhash_destroy(&ext);
 }
 
 bool AssetState::handleAssetMessage(fty_proto_t* message)

--- a/src/asset_state.cc
+++ b/src/asset_state.cc
@@ -70,6 +70,7 @@ AssetState::Asset::Asset(fty_proto_t* message)
         }
     }
     zhash_destroy(&ext);
+    proto_ = fty_proto_dup(message);
 }
 
 bool AssetState::handleAssetMessage(fty_proto_t* message)

--- a/src/asset_state.h
+++ b/src/asset_state.h
@@ -35,6 +35,10 @@ public:
         // never modified, since different instances of AssetState may
         // share a pointer to it
         explicit Asset(fty_proto_t *message);
+        ~Asset()
+        {
+            fty_proto_destroy(&proto_);
+        }
         const std::string& name() const
         {
             return name_;
@@ -87,6 +91,10 @@ public:
         {
             return endpoint_;
         }
+        fty_proto_t* proto() const
+        {
+            return proto_;
+        }
     private:
         std::string name_;
         std::string IP_;
@@ -100,6 +108,7 @@ public:
         bool have_upsconf_block_;
         bool upsconf_enable_dmf_;
         int daisychain_;
+        fty_proto_t* proto_;
     };
     // Update the state from a received fty_proto message. Return true if an
     // update has actually been performed, false if the message was skipped

--- a/src/asset_state.h
+++ b/src/asset_state.h
@@ -79,6 +79,14 @@ public:
         {
             return daisychain_;
         }
+        bool has_endpoint() const
+        {
+            return !endpoint_.empty();
+        }
+        const std::map<std::string, std::string>& endpoint() const
+        {
+            return endpoint_;
+        }
     private:
         std::string name_;
         std::string IP_;
@@ -86,6 +94,7 @@ public:
         std::string subtype_;
         std::string location_;
         std::string upsconf_block_;
+        std::map<std::string, std::string> endpoint_;
         double max_current_;
         double max_power_;
         bool have_upsconf_block_;

--- a/src/nut_configurator.cc
+++ b/src/nut_configurator.cc
@@ -305,7 +305,7 @@ fty::nut::DeviceConfigurations NUTConfigurator::getConfigurationFromEndpoint(con
 
             auto const& endpoint = info.asset->endpoint();
             if (endpoint.at("protocol") == "nut_xml_pdc") {
-                std::string port = IP;
+                std::string port = std::string("http://") + IP;
                 if (endpoint.count("port")) {
                     port = port + ":" + endpoint.at("port");
                 }

--- a/src/nut_configurator.cc
+++ b/src/nut_configurator.cc
@@ -283,7 +283,6 @@ fty::nut::DeviceConfigurations NUTConfigurator::getConfigurationFromUpsConfBlock
 
 fty::nut::DeviceConfigurations NUTConfigurator::getConfigurationFromEndpoint(const std::string &name, const AutoConfigurationInfo &info)
 {
-    const int scanTimeout = 10;
     const std::string& IP = info.asset->IP();
     fty::nut::DeviceConfigurations configs;
 

--- a/src/nut_configurator.h
+++ b/src/nut_configurator.h
@@ -61,7 +61,7 @@ class NUTConfigurator {
     void updateNUTConfig();
     fty::nut::DeviceConfigurations getConfigurationFromUpsConfBlock(const std::string &name, const AutoConfigurationInfo &info);
     fty::nut::DeviceConfigurations getConfigurationFromEndpoint(const std::string &name, const AutoConfigurationInfo &info);
-    fty::nut::DeviceConfigurations getConfigurationFromScanningDevice(const std::string &name, const AutoConfigurationInfo &info);
+    void updateAssetFromScanningDevice(const std::string &name, const AutoConfigurationInfo &info);
     void updateDeviceConfiguration(const std::string &name, const AutoConfigurationInfo &info, fty::nut::DeviceConfiguration config);
     static void systemctl( const std::string &operation, const std::string &service );
     template<typename It>

--- a/src/nut_configurator.h
+++ b/src/nut_configurator.h
@@ -60,6 +60,7 @@ class NUTConfigurator {
     fty::nut::DeviceConfigurations::const_iterator selectBestConfiguration(const fty::nut::DeviceConfigurations &configs);
     void updateNUTConfig();
     fty::nut::DeviceConfigurations getConfigurationFromUpsConfBlock(const std::string &name, const AutoConfigurationInfo &info);
+    fty::nut::DeviceConfigurations getConfigurationFromEndpoint(const std::string &name, const AutoConfigurationInfo &info);
     fty::nut::DeviceConfigurations getConfigurationFromScanningDevice(const std::string &name, const AutoConfigurationInfo &info);
     void updateDeviceConfiguration(const std::string &name, const AutoConfigurationInfo &info, fty::nut::DeviceConfiguration config);
     static void systemctl( const std::string &operation, const std::string &service );


### PR DESCRIPTION
This PR makes fty-nut-configurator aware of the first endpoint in an asset and configures it for NUT if it's recognized (currently SNMP and NetXML types). For backwards compatibility, if an asset has no endpoints it will trigger the legacy configuration codepath, converts the result to an endpoint and updates the asset accordingly.

It is a minimally-intrusive set of modifications since fty-nut-configurator was not really designed for this in the first place. We'll need a real overhaul of this agent eventually along with the rest of fty-nut so that the following is properly handled:
- Multiple endpoints configurations
- Multi-homing
- Daisy-chaining not dependent on the host being active to work
- Endpoint connectivity status
- Fallbacks in case of communication lost
- ...