### PR TITLE
Add nut_powercom endpoint support

### DIFF
--- a/src/nut_configurator.cc
+++ b/src/nut_configurator.cc
@@ -324,6 +324,13 @@ fty::nut::DeviceConfigurations NUTConfigurator::getConfigurationFromEndpoint(con
                 config.emplace("port", port);
                 configs = { config };
             }
+            else if (endpoint.at("protocol") == "nut_powercom") {
+                auto config = fty::nut::convertSecwDocumentToKeyValues(secws.at(endpoint.at("nut_powercom.secw_credential_id")), "etn-nut-powercom");
+                config.emplace("driver", "etn-nut-powercom");
+                config.emplace("port", IP);
+                config.emplace("auto", "true");
+                configs = { config };
+            }
             else {
                 throw std::runtime_error((std::string("Unknown protocol ")+endpoint.at("protocol")).c_str());
             }


### PR DESCRIPTION
Note: logically depends on https://github.com/42ity/fty-common-nut/pull/27

Also: asset extended property keytag `endpoint.1.nut_powercom.secw_credential_id` is too long for our current DB schema (max. 40 characters currently), it is in the process of being upgraded by @perrettecl.