### PR TITLE
fix IPMVAL-1382

### DIFF
--- a/lib/src/alert_device.h
+++ b/lib/src/alert_device.h
@@ -67,7 +67,7 @@ public:
     void nutName(const std::string& aName)
     {
         _nutName = aName;
-    };
+    }
     std::string nutName() const
     {
         return _nutName;
@@ -75,6 +75,10 @@ public:
     std::string assetName() const
     {
         return _asset ? _asset->name() : std::string();
+    }
+    std::string assetFriendlyName() const
+    {
+        return _asset ? _asset->friendlyName() : std::string();
     }
     int chain() const
     {

--- a/lib/src/asset_state.cc
+++ b/lib/src/asset_state.cc
@@ -27,7 +27,8 @@
 
 AssetState::Asset::Asset(fty_proto_t* message)
 {
-    name_             = fty_proto_name(message);
+    name_             = fty_proto_name(message); // iname
+    friendlyName_     = fty_proto_ext_string(message, "name", "");
     serial_           = fty_proto_ext_string(message, "serial_no", "");
     IP_               = fty_proto_ext_string(message, "ip.1", "");
     port_             = fty_proto_ext_string(message, "port", "");

--- a/lib/src/asset_state.h
+++ b/lib/src/asset_state.h
@@ -45,6 +45,10 @@ public:
         {
             return name_;
         }
+        const std::string& friendlyName() const
+        {
+            return friendlyName_;
+        }
         const std::string& serial() const
         {
             return serial_;
@@ -120,6 +124,7 @@ public:
 
     private:
         std::string                        name_;
+        std::string                        friendlyName_;
         std::string                        serial_;
         std::string                        IP_;
         std::string                        port_;


### PR DESCRIPTION
for the produced threshold rules (source: NUT, class: Device internal)

update json payload sent to fty-alert-engine:
- handle friendlyName
- set the rule name (displayed label) more human readable
- fix results/description payloads (json stringified)
Signed-off-by: Francois-Regis Degott <FrancoisRegisDegott@eaton.com>